### PR TITLE
Allow user-set test particle seed region

### DIFF
--- a/PARAM.XML
+++ b/PARAM.XML
@@ -694,7 +694,7 @@ REFINEREGION_FLEKS2" multiple="T">
   <parameter name="refineLev" type="integer" min="0"/>
   <parameter name="refineArea" type="string" />
 
-#TPINITREGION
+#TPREGION
 +box1         		        StringRegion
 
 This command is used to specify the regions of test particle seeds. The cells
@@ -791,15 +791,15 @@ The starting supID for each species. This command should only exist in
 a restart file.
 </command>
 
-<command name="TPREGION"
-	 alias="TPREGION_FLEKS0,TPREGION_FLEKS1,TPREGION_FLEKS2"
+<command name="TPSEED"
+	 alias="TPSEED_FLEKS0,TPSEED_FLEKS1,TPSEED_FLEKS2"
 	 multiple="T">
   <parameter name="region" type="string"/>     
 
-#TPREGION
+#TPSEED
 boundary           region
 
-#TPREGION_FLEKS0
+#TPSEED_FLEKS0
 uniform           region
 
 Users can choose generating test particles either in the whole 
@@ -862,7 +862,7 @@ This command sets the number of test particles per cell.
 
 Generating test particles for every cell may be too much for large applications. 
 This command allows generating test particles for every nInterval cells in the
-region defined by command #TPREGION. If the interval is larger than those
+region defined by command #TPSEED. If the interval is larger than those
 defined in #MAXBLOCKSIZE, the interval is equivalent to the maximum block size.
 </command>
 

--- a/PARAM.XML
+++ b/PARAM.XML
@@ -675,17 +675,30 @@ REFINEREGION_FLEKS2" multiple="T">
 
 #REFINEREGION
 0                         refineLev
-+box1 -sphere1		        StringHallRegion
++box1 -sphere1		        StringRegion
 
 #REFINEREGION
 1                         refineLev
-+box2 -sphere2		        StringHallRegion
++box2 -sphere2		        StringRegion
 
 This command is used to specify the regions of refinement for the 
 level refineLev. The cells inside the '+' shapes but outside the '-' 
 shapes will be refined.
 
 Multiple #REFINEREGION commands can be used for different levels.
+
+</command>
+
+<command name="REFINEREGION" alias="REFINEREGION_FLEKS0,REFINEREGION_FLEKS1,
+REFINEREGION_FLEKS2" multiple="T">
+  <parameter name="refineLev" type="integer" min="0"/>
+  <parameter name="refineArea" type="string" />
+
+#TPINITREGION
++box1         		        StringRegion
+
+This command is used to specify the regions of test particle seeds. The cells
+inside the '+' shapes but outside the '-' shapes will be selected.
 
 </command>
 
@@ -790,7 +803,9 @@ boundary           region
 uniform           region
 
 Users can choose generating test particles either in the whole 
-domain (uniform), at all the boundaries, or on a single boundary (side).
+domain, at all the boundaries, on a single boundary, or in a user
+defined region.
+Options of region are 'uniform', 'boundary', 'side', or 'user'.
 </command>
 
 <command name="TPSTATESI"

--- a/PARAM.XML
+++ b/PARAM.XML
@@ -689,19 +689,6 @@ Multiple #REFINEREGION commands can be used for different levels.
 
 </command>
 
-<command name="REFINEREGION" alias="REFINEREGION_FLEKS0,REFINEREGION_FLEKS1,
-REFINEREGION_FLEKS2" multiple="T">
-  <parameter name="refineLev" type="integer" min="0"/>
-  <parameter name="refineArea" type="string" />
-
-#TPREGION
-+box1         		        StringRegion
-
-This command is used to specify the regions of test particle seeds. The cells
-inside the '+' shapes but outside the '-' shapes will be selected.
-
-</command>
-
 <command name="GRIDEFFICIENCY" alias="GRIDEFFICIENCY_FLEKS0,GRIDEFFICIENCY_FLEKS1,
 GRIDEFFICIENCY_FLEKS2" multiple="T">
   <parameter name="gridEfficiency" type="real" min="0" max="1" default="0.7"/>
@@ -791,21 +778,28 @@ The starting supID for each species. This command should only exist in
 a restart file.
 </command>
 
-<command name="TPSEED"
-	 alias="TPSEED_FLEKS0,TPSEED_FLEKS1,TPSEED_FLEKS2"
-	 multiple="T">
+<command name="TPREGION"
+	 alias="TPREGION_FLEKS0,TPREGION_FLEKS1,TPREGION_FLEKS2"
+	 multiple="F">
   <parameter name="region" type="string"/>     
 
-#TPSEED
+#TPREGION
 boundary           region
 
-#TPSEED_FLEKS0
-uniform           region
+#TPREGION_FLEKS0
+uniform            region
 
-Users can choose generating test particles either in the whole 
-domain, at all the boundaries, on a single boundary, or in a user
-defined region.
-Options of region are 'uniform', 'boundary', 'side', or 'user'.
+#TPREGION
++box1         		 region
+
+This command is used to specify the regions of test particle seeds. 
+Users can choose the option of generating test particles:
+* 'uniform': in the whole domain
+* 'boundary': at all the boundaries
+* 'sideX+': at the X+ boundary
+* '+/-region': in a user defined region, used together with #REGION.
+Cells inside the '+' shapes and outside the '-' shapes will be selected.
+
 </command>
 
 <command name="TPSTATESI"
@@ -862,7 +856,7 @@ This command sets the number of test particles per cell.
 
 Generating test particles for every cell may be too much for large applications. 
 This command allows generating test particles for every nInterval cells in the
-region defined by command #TPSEED. If the interval is larger than those
+region defined by command #TPREGION. If the interval is larger than those
 defined in #MAXBLOCKSIZE, the interval is equivalent to the maximum block size.
 </command>
 

--- a/include/Grid.h
+++ b/include/Grid.h
@@ -345,7 +345,7 @@ public:
   // ‘fit” the data. (4) The algorithm should be fast.
 
   // 3. So, even the AMR buffer size is 0 (amrInfo.n_error_buf), the cells
-  // that are not tagged in ErrorEst() may still be refined du to the
+  // that are not tagged in ErrorEst() may still be refined due to the
   // clustering algorithm. Tests show the clustering is pretty smart.
   virtual void ErrorEst(int iLev, amrex::TagBoxArray& tags, amrex::Real time,
                         int ngrow) override {

--- a/include/ParticleTracker.h
+++ b/include/ParticleTracker.h
@@ -44,6 +44,8 @@ public:
   void read_param(const std::string &command, ReadParam &param);
   void write_log(bool doForce = false, bool doCreateFile = false);
 
+  void set_tp_init_shapes(amrex::Vector<std::shared_ptr<Shape>> shapes);
+
 private:
   TimeCtr *tc = nullptr;
   FluidInterface *fi = nullptr;
@@ -74,6 +76,10 @@ private:
   amrex::Vector<Vel> tpStates;
 
   std::string logFile;
+
+  // Test Particle initialization regions
+  std::string sTPRegion;
+  amrex::Vector<std::shared_ptr<Shape>> tpShapes;
 };
 
 #endif

--- a/include/ParticleTracker.h
+++ b/include/ParticleTracker.h
@@ -64,7 +64,7 @@ private:
   amrex::IntVect nTPPerCell = { AMREX_D_DECL(1, 1, 1) };
   amrex::IntVect nTPIntervalCell = { AMREX_D_DECL(1, 1, 1) };
 
-  std::string sPartRegion;
+  std::string sSeed;
 
   std::string sIOUnit = "planet";
 
@@ -78,7 +78,7 @@ private:
   std::string logFile;
 
   // Test Particle initialization regions
-  std::string sTPRegion;
+  std::string sRegion;
   amrex::Vector<std::shared_ptr<Shape>> tpShapes;
 };
 

--- a/include/ParticleTracker.h
+++ b/include/ParticleTracker.h
@@ -64,8 +64,6 @@ private:
   amrex::IntVect nTPPerCell = { AMREX_D_DECL(1, 1, 1) };
   amrex::IntVect nTPIntervalCell = { AMREX_D_DECL(1, 1, 1) };
 
-  std::string sSeed;
-
   std::string sIOUnit = "planet";
 
   bool isRelativistic = false;

--- a/include/ParticleTracker.h
+++ b/include/ParticleTracker.h
@@ -44,7 +44,7 @@ public:
   void read_param(const std::string &command, ReadParam &param);
   void write_log(bool doForce = false, bool doCreateFile = false);
 
-  void set_tp_init_shapes(amrex::Vector<std::shared_ptr<Shape>> shapes);
+  void set_tp_init_shapes(amrex::Vector<std::shared_ptr<Shape>>& shapes);
 
 private:
   TimeCtr *tc = nullptr;

--- a/include/Regions.h
+++ b/include/Regions.h
@@ -34,7 +34,7 @@ public:
     }
   }
 
-  // Does the 'shape' in the 'list'?
+  // Is the 'shape' in the 'list'?
   bool contains(const Shape* shape,
                 const amrex::Vector<std::string>& list) const {
     bool doContain = false;
@@ -62,7 +62,7 @@ public:
   // Is the point 'xyz' inside the include list but outside the exclude list?
   bool is_inside(amrex::Real* xyz) const {
     bool isIncluded = false;
-    for (auto& shape : shapes) {      
+    for (auto& shape : shapes) {
       if (is_include(shape))
         isIncluded = shape->is_inside(xyz);
 

--- a/include/TestParticles.h
+++ b/include/TestParticles.h
@@ -78,18 +78,19 @@ public:
 
   void set_interval(amrex::IntVect in) { nIntervalCell = in; };
 
-  void set_particle_region(std::string& sSeed, std::string& sRegion,
+  void set_particle_region(std::string& sRegion,
                            amrex::Vector<std::shared_ptr<Shape> >& shapes) {
-    if (!sSeed.empty()) {
-      if (sSeed.find("boundary") != std::string::npos) {
-        iPartRegion = iRegionBoundary_;
-      } else if (sSeed.find("uniform") != std::string::npos) {
-        iPartRegion = iRegionUniform_;
-      } else if (sSeed.find("sideX+") != std::string::npos) {
-        iPartRegion = iRegionSideXp_;
-      } else if (sSeed.find("user") != std::string::npos) {
+    if (!sRegion.empty()) {
+      //TODO: std::string::starts_with (C++20)
+      if (sRegion[0] == '+' || sRegion[0] == '-') {
         iPartRegion = iRegionUser_;
         tpRegions = Regions(shapes, sRegion);
+      } else if (sRegion == "boundary") {
+        iPartRegion = iRegionBoundary_;
+      } else if (sRegion == "uniform") {
+        iPartRegion = iRegionUniform_;
+      } else if (sRegion == "sideX+") {
+        iPartRegion = iRegionSideXp_;
       } else {
         amrex::Abort("Error:Unknown test particle region!");
       }

--- a/include/TestParticles.h
+++ b/include/TestParticles.h
@@ -78,18 +78,18 @@ public:
 
   void set_interval(amrex::IntVect in) { nIntervalCell = in; };
 
-  void set_particle_region(std::string& sRegion, std::string& sTPRegion,
+  void set_particle_region(std::string& sSeed, std::string& sRegion,
                            amrex::Vector<std::shared_ptr<Shape> >& shapes) {
-    if (!sRegion.empty()) {
-      if (sRegion.find("boundary") != std::string::npos) {
+    if (!sSeed.empty()) {
+      if (sSeed.find("boundary") != std::string::npos) {
         iPartRegion = iRegionBoundary_;
-      } else if (sRegion.find("uniform") != std::string::npos) {
+      } else if (sSeed.find("uniform") != std::string::npos) {
         iPartRegion = iRegionUniform_;
-      } else if (sRegion.find("sideX+") != std::string::npos) {
+      } else if (sSeed.find("sideX+") != std::string::npos) {
         iPartRegion = iRegionSideXp_;
-      } else if (sRegion.find("user") != std::string::npos) {
+      } else if (sSeed.find("user") != std::string::npos) {
         iPartRegion = iRegionUser_;
-        tpRegions = Regions(shapes, sTPRegion);
+        tpRegions = Regions(shapes, sRegion);
       } else {
         amrex::Abort("Error:Unknown test particle region!");
       }

--- a/include/TestParticles.h
+++ b/include/TestParticles.h
@@ -24,6 +24,7 @@ private:
   static constexpr int iRegionBoundary_ = 1;
   static constexpr int iRegionUniform_ = 2;
   static constexpr int iRegionSideXp_ = 3;
+  static constexpr int iRegionUser_ = 4;
 
 public:
   TestParticles(Grid* gridIn, FluidInterface* const fluidIn,
@@ -77,7 +78,8 @@ public:
 
   void set_interval(amrex::IntVect in) { nIntervalCell = in; };
 
-  void set_particle_region(std::string& sRegion) {
+  void set_particle_region(std::string& sRegion, std::string& sTPRegion,
+                           amrex::Vector<std::shared_ptr<Shape> >& shapes) {
     if (!sRegion.empty()) {
       if (sRegion.find("boundary") != std::string::npos) {
         iPartRegion = iRegionBoundary_;
@@ -85,6 +87,9 @@ public:
         iPartRegion = iRegionUniform_;
       } else if (sRegion.find("sideX+") != std::string::npos) {
         iPartRegion = iRegionSideXp_;
+      } else if (sRegion.find("user") != std::string::npos) {
+        iPartRegion = iRegionUser_;
+        tpRegions = Regions(shapes, sTPRegion);
       } else {
         amrex::Abort("Error:Unknown test particle region!");
       }
@@ -139,6 +144,8 @@ private:
   unsigned long int nInitPart;
 
   std::vector<PID> vIDs;
+
+  Regions tpRegions;
 };
 
 #endif

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -838,10 +838,10 @@ void Domain::read_param(const bool readGridInfo) {
         command == "#SELECTPARTICLE") {
       pic->read_param(command, param);
     } else if (command == "#TESTPARTICLENUMBER" || command == "#TPPARTICLES" ||
-               command == "#TPCELLINTERVAL" || command == "#TPREGION" ||
+               command == "#TPCELLINTERVAL" || command == "#TPSEED" ||
                command == "#TPSAVE" || command == "#TPRELATIVISTIC" ||
                command == "#TPINITFROMPIC" || command == "#TPSTATESI" ||
-               command == "#TPINITREGION") {
+               command == "#TPREGION") {
       if (pt)
         pt->read_param(command, param);
     } else if (command == "#NORMALIZATION" || command == "#SCALINGFACTOR" ||

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -840,7 +840,8 @@ void Domain::read_param(const bool readGridInfo) {
     } else if (command == "#TESTPARTICLENUMBER" || command == "#TPPARTICLES" ||
                command == "#TPCELLINTERVAL" || command == "#TPREGION" ||
                command == "#TPSAVE" || command == "#TPRELATIVISTIC" ||
-               command == "#TPINITFROMPIC" || command == "#TPSTATESI") {
+               command == "#TPINITFROMPIC" || command == "#TPSTATESI" ||
+               command == "#TPINITREGION") {
       if (pt)
         pt->read_param(command, param);
     } else if (command == "#NORMALIZATION" || command == "#SCALINGFACTOR" ||
@@ -1152,8 +1153,10 @@ void Domain::read_param(const bool readGridInfo) {
     if (pic)
       pic->post_process_param();
 
-    if (pt)
+    if (pt) {
       pt->post_process_param();
+      pt->set_tp_init_shapes(shapes);
+    }
 
     if (fi)
       fi->post_process_param(receiveICOnly);

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -838,10 +838,9 @@ void Domain::read_param(const bool readGridInfo) {
         command == "#SELECTPARTICLE") {
       pic->read_param(command, param);
     } else if (command == "#TESTPARTICLENUMBER" || command == "#TPPARTICLES" ||
-               command == "#TPCELLINTERVAL" || command == "#TPSEED" ||
+               command == "#TPCELLINTERVAL" || command == "#TPREGION" ||
                command == "#TPSAVE" || command == "#TPRELATIVISTIC" ||
-               command == "#TPINITFROMPIC" || command == "#TPSTATESI" ||
-               command == "#TPREGION") {
+               command == "#TPINITFROMPIC" || command == "#TPSTATESI") {
       if (pt)
         pt->read_param(command, param);
     } else if (command == "#NORMALIZATION" || command == "#SCALINGFACTOR" ||

--- a/src/ParticleTracker.cpp
+++ b/src/ParticleTracker.cpp
@@ -180,7 +180,7 @@ void ParticleTracker::post_regrid() {
                             fi->get_species_mass(i), gridID));
       ptr->set_ppc(nTPPerCell);
       ptr->set_interval(nTPIntervalCell);
-      ptr->set_particle_region(sSeed, sRegion, tpShapes);
+      ptr->set_particle_region(sRegion, tpShapes);
       ptr->set_relativistic(isRelativistic);
       parts.push_back(std::move(ptr));
     }
@@ -279,8 +279,6 @@ void ParticleTracker::read_param(const std::string& command, ReadParam& param) {
     param.read_var("nIntervalX", nTPIntervalCell[ix_]);
     param.read_var("nIntervalY", nTPIntervalCell[iy_]);
     param.read_var("nIntervalZ", nTPIntervalCell[iz_]);
-  } else if (command == "#TPSEED") {
-    param.read_var("seedRegion", sSeed);
   } else if (command == "#TPREGION") {
     param.read_var("region", sRegion);
   } else if (command == "#TPSAVE") {

--- a/src/ParticleTracker.cpp
+++ b/src/ParticleTracker.cpp
@@ -195,7 +195,7 @@ void ParticleTracker::post_regrid() {
 }
 
 void ParticleTracker::set_tp_init_shapes(
-    amrex::Vector<std::shared_ptr<Shape> > shapes) {
+    amrex::Vector<std::shared_ptr<Shape> >& shapes) {
   tpShapes = shapes;
 }
 

--- a/src/ParticleTracker.cpp
+++ b/src/ParticleTracker.cpp
@@ -180,7 +180,7 @@ void ParticleTracker::post_regrid() {
                             fi->get_species_mass(i), gridID));
       ptr->set_ppc(nTPPerCell);
       ptr->set_interval(nTPIntervalCell);
-      ptr->set_particle_region(sPartRegion, sTPRegion, tpShapes);
+      ptr->set_particle_region(sSeed, sRegion, tpShapes);
       ptr->set_relativistic(isRelativistic);
       parts.push_back(std::move(ptr));
     }
@@ -279,10 +279,10 @@ void ParticleTracker::read_param(const std::string& command, ReadParam& param) {
     param.read_var("nIntervalX", nTPIntervalCell[ix_]);
     param.read_var("nIntervalY", nTPIntervalCell[iy_]);
     param.read_var("nIntervalZ", nTPIntervalCell[iz_]);
+  } else if (command == "#TPSEED") {
+    param.read_var("seedRegion", sSeed);
   } else if (command == "#TPREGION") {
-    param.read_var("region", sPartRegion);
-  } else if (command == "#TPINITREGION") {
-    param.read_var("region", sTPRegion);
+    param.read_var("region", sRegion);
   } else if (command == "#TPSAVE") {
     param.read_var("IOUnit", sIOUnit);
     param.read_var("dnSave", dnSave);

--- a/src/ParticleTracker.cpp
+++ b/src/ParticleTracker.cpp
@@ -180,7 +180,7 @@ void ParticleTracker::post_regrid() {
                             fi->get_species_mass(i), gridID));
       ptr->set_ppc(nTPPerCell);
       ptr->set_interval(nTPIntervalCell);
-      ptr->set_particle_region(sPartRegion);
+      ptr->set_particle_region(sPartRegion, sTPRegion, tpShapes);
       ptr->set_relativistic(isRelativistic);
       parts.push_back(std::move(ptr));
     }
@@ -192,6 +192,11 @@ void ParticleTracker::post_regrid() {
     }
   }
   //--------------test particles-----------------------------------
+}
+
+void ParticleTracker::set_tp_init_shapes(
+    amrex::Vector<std::shared_ptr<Shape> > shapes) {
+  tpShapes = shapes;
 }
 
 void ParticleTracker::save_restart_data() {
@@ -276,6 +281,8 @@ void ParticleTracker::read_param(const std::string& command, ReadParam& param) {
     param.read_var("nIntervalZ", nTPIntervalCell[iz_]);
   } else if (command == "#TPREGION") {
     param.read_var("region", sPartRegion);
+  } else if (command == "#TPINITREGION") {
+    param.read_var("region", sTPRegion);
   } else if (command == "#TPSAVE") {
     param.read_var("IOUnit", sIOUnit);
     param.read_var("dnSave", dnSave);


### PR DESCRIPTION
This PR allows to set initial seed regions for test particles using #TPREGION and #REGION commands.

The original #TPREGION command is renamed to #TPSEED, and we introduce a new #TPREGION command for setting the seed regions based on the region types defined by #REGION. This change requires modifying the test16_3d PARAM.in file accordingly for test16_3d to pass.

The first implementation may need some improvements. `shapes` is stored in `DomainGrid.h`. I define `Regions tpRegions` in `TestParticles.h`. In order to set its value, I need to pass `shapes` from `DomainGrid.h` to `ParticleTracker.cpp`. This is first handled by defining a private `amrex::Vector<std::shared_ptr<Shape> > tpShapes` and then adding `pt->set_tp_init_shapes(shapes)` after `pt->post_process_param()` in `Domain.cpp read_param()` to copy `shapes` into `tpShapes`. How can I avoid the copy and simply pass the reference of `shapes` to `tpShapes`?

-----

I am also thinking of modifying the test particle tests. Do you think we need a separate test for test particles beside test16_3d @yuxi-chen? The current one tests uniform seeding for every cell in the physical domain, which is less likely to be used in production runs.
