### PR TITLE
Add b field gradient to test particle

### DIFF
--- a/Config.pl
+++ b/Config.pl
@@ -47,7 +47,7 @@ our $WARNING;
 
 my $TPSave = "P";
 my $NewTPSave;
-my %nTPString=(7=>'P', 10=>'PB', 13=>'PBE', 22=>'PBEG');
+my %nTPString=(7=>'P', 10=>'PB', 13=>'PBE', 19=>'PBEG', 22=>'PBEG');
 my %nTPSave=('P' => 7, 'PB' => 10, 'PBE' => 13, 'PBEG' => 22);
 my %TPInfo=('P' => "Particle", 'PB' => "Particle+B", 'PBE' => "Particle+B+E", 'PBEG' => "Particle+B+E+GradB");
 
@@ -131,7 +131,14 @@ sub set_test_particle{
     $TPSave = $NewTPSave if $NewTPSave;
 
     my $NameConstFile = "include/Constants.h";
-    my $nSize = $nTPSave{$TPSave};     
+    my $nSize = $nTPSave{$TPSave};
+    if($TPSave eq 'PBEG'){
+        if($AmrexDim == 2){
+            $nSize = 19;
+        }else{
+            $nSize = 22;
+        }
+    }
     @ARGV = ($NameConstFile);
     while(<>){
         s/\b(ptRecordSize\s*=[^0-9]*)(\d+)/$1$nSize/i;
@@ -162,6 +169,7 @@ sub print_help{
               PB: particle + magnetic field. 
               PBE: particle + magnetic field + electric field
               PBEG: particle + B-field + E-field + gradient of B-field
+                    (size is 22 for 3D, 19 for 2D)
 
 \n";
     exit -0;

--- a/Config.pl
+++ b/Config.pl
@@ -47,9 +47,9 @@ our $WARNING;
 
 my $TPSave = "P";
 my $NewTPSave;
-my %nTPString=(7=>'P', 10=>'PB', 13=>'PBE');
-my %nTPSave=('P' => 7, 'PB' => 10, 'PBE' => 13);
-my %TPInfo=('P' => "Particle", 'PB' => "Particle+B", 'PBE' => "Particle+B+E");
+my %nTPString=(7=>'P', 10=>'PB', 13=>'PBE', 22=>'PBEG');
+my %nTPSave=('P' => 7, 'PB' => 10, 'PBE' => 13, 'PBEG' => 22);
+my %TPInfo=('P' => "Particle", 'PB' => "Particle+B", 'PBE' => "Particle+B+E", 'PBEG' => "Particle+B+E+GradB");
 
 my $AmrexDim;
 
@@ -64,7 +64,7 @@ foreach (@Arguments){
      warn "WARNING: Unknown flag $_\n" if $Remaining{$_};
 }
 
-die "$ERROR -tp input should be 'P', 'PB', or 'PBE'.\n" 
+die "$ERROR -tp input should be 'P', 'PB', 'PBE', or 'PBEG'.\n"
     if $NewTPSave and not exists $nTPSave{$NewTPSave};
 
 my $AmrexComp;
@@ -157,10 +157,11 @@ sub print_help{
 
 -lev          Number of maximum grid levels. It is a uniform grid without AMR if lev=1.	
 
--tp=P,PB,PBE  Test particle output information. 
+-tp=P,PB,PBE,PBEG  Test particle output information.
               P: only save particle velocity + location
               PB: particle + magnetic field. 
               PBE: particle + magnetic field + electric field
+              PBEG: particle + B-field + E-field + gradient of B-field
 
 \n";
     exit -0;

--- a/include/TestParticles.h
+++ b/include/TestParticles.h
@@ -19,6 +19,15 @@ public:
   static constexpr int iTPEx_ = 10;
   static constexpr int iTPEy_ = 11;
   static constexpr int iTPEz_ = 12;
+  static constexpr int iTPdBxdx_ = 13;
+  static constexpr int iTPdBxdy_ = 14;
+  static constexpr int iTPdBxdz_ = 15;
+  static constexpr int iTPdBydx_ = 16;
+  static constexpr int iTPdBydy_ = 17;
+  static constexpr int iTPdBydz_ = 18;
+  static constexpr int iTPdBzdx_ = 19;
+  static constexpr int iTPdBzdy_ = 20;
+  static constexpr int iTPdBzdz_ = 21;
 
 private:
   static constexpr int iRegionBoundary_ = 1;

--- a/include/TestParticles.h
+++ b/include/TestParticles.h
@@ -3,6 +3,7 @@
 
 #include "BitArray.h"
 #include "Particles.h"
+#include "AMReX_Config.H"
 
 class TestParticles : public PTParticles {
 public:
@@ -19,6 +20,7 @@ public:
   static constexpr int iTPEx_ = 10;
   static constexpr int iTPEy_ = 11;
   static constexpr int iTPEz_ = 12;
+#if (AMREX_SPACEDIM == 3)
   static constexpr int iTPdBxdx_ = 13;
   static constexpr int iTPdBxdy_ = 14;
   static constexpr int iTPdBxdz_ = 15;
@@ -28,6 +30,14 @@ public:
   static constexpr int iTPdBzdx_ = 19;
   static constexpr int iTPdBzdy_ = 20;
   static constexpr int iTPdBzdz_ = 21;
+#else
+  static constexpr int iTPdBxdx_ = 13;
+  static constexpr int iTPdBxdy_ = 14;
+  static constexpr int iTPdBydx_ = 15;
+  static constexpr int iTPdBydy_ = 16;
+  static constexpr int iTPdBzdx_ = 17;
+  static constexpr int iTPdBzdy_ = 18;
+#endif
 
 private:
   static constexpr int iRegionBoundary_ = 1;

--- a/src/TestParticles.cpp
+++ b/src/TestParticles.cpp
@@ -182,7 +182,7 @@ void TestParticles::move_and_save_charged_particles(const MultiFab& nodeEMF,
           p.rdata(i0 + iTPEz_) = ep[iz_];
         }
 
-        if (ptRecordSize >= 22) {
+        if (ptRecordSize > 13) {
           // The gradient calculation is based on the derivative of the trilinear
           // interpolation shape functions.
           // B(x,y,z) = sum_{i,j,k} B_{i,j,k} * W_i(x) * W_j(y) * W_k(z)
@@ -682,7 +682,7 @@ unsigned long long int TestParticles::loop_particles(
             recordData[iTPEz_] = (float)(p.rdata(i0 + iTPEz_) * no2outE);
           }
 
-          if (ptRecordSize >= 22) {
+          if (ptRecordSize > 13) {
             // no2out for gradient is no2outB/no2outL
             Real no2outG = no2outB / no2outL;
             recordData[iTPdBxdx_] = (float)(p.rdata(i0 + iTPdBxdx_) * no2outG);


### PR DESCRIPTION
This PR adds the option to add $\nabla B$ along the particle trajectory. @yuxi-chen Can you review the changes to see if it works? We probably also need to add tests for particles with EM field and this new gradient values.