### PR TITLE
feat: Make test particle parameters configurable

### DIFF
--- a/PARAM.XML
+++ b/PARAM.XML
@@ -208,18 +208,22 @@ particle tracker components, respectively.
 <command name="TPSAVE"
 	 alias="TPSAVE_FLEKS0,TPSAVE_FLEKS1,TPSAVE_FLEKS2"
 	 multiple="T">
+  <parameter name="iSpecies" type="integer" required="T"/>
   <parameter name="unit" type="string" input="select">
     <option value="si"     name="SI units"/>
     <option value="planet" name="planet units" default="T"/>
     <option value="pic"    name="PIC normalized units"/>
   </parameter>
   <parameter name="dnSave" type="integer" default="1"/>
+  <parameter name="launchThreshold" type="real" min="0.0" max="1.0" default="0.5"/>
 
 #TPSAVE
+0                          iSpecies
 planet                     unit
 10                         dnSave
+0.5                        launchThreshold
 
-The unit and frequence of saving test particles.
+The unit and frequence of saving test particles, and the threshold for relaunching particles.
 
 </command>
 

--- a/include/ParticleTracker.h
+++ b/include/ParticleTracker.h
@@ -13,6 +13,8 @@ public:
                   int nGst, FluidInterface *fluidIn, TimeCtr *tcIn, int id)
       : Grid(gm, amrInfo, nGst, id, "pt"), tc(tcIn), fi(fluidIn) {
     nSpecies = fi->get_nS();
+    dnSave.resize(nSpecies, 10);
+    launchThreshold.resize(nSpecies, 0.5);
   };
 
   ~ParticleTracker() {
@@ -59,7 +61,8 @@ private:
   amrex::Vector<unsigned long int> initPartNumber;
 
   std::unique_ptr<PlotCtr> savectr;
-  int dnSave = 1;
+  amrex::Vector<int> dnSave;
+  amrex::Vector<amrex::Real> launchThreshold;
 
   amrex::IntVect nTPPerCell = { AMREX_D_DECL(1, 1, 1) };
   amrex::IntVect nTPIntervalCell = { AMREX_D_DECL(1, 1, 1) };


### PR DESCRIPTION
This commit introduces two main changes to the test particle module:

1.  The particle re-launching threshold is now a configurable parameter. Previously, it was a hardcoded value (0.5). A new `launchThreshold` parameter has been added to the `TPSAVE` command in `PARAM.XML` to control this threshold.

2.  The output frequency for test particles can now be set on a per-species basis. A new `iSpecies` parameter has been added to the `TPSAVE` command to specify which species the settings apply to. This allows for different `dnSave` values for each species.

The internal data structures in `ParticleTracker` have been updated to store these parameters as vectors, with one entry per species. The parameter reading and update logic have been modified accordingly.