### PR TITLE
feature: Add a new Jacobian calculation method for test particles

### DIFF
--- a/PARAM.XML
+++ b/PARAM.XML
@@ -548,6 +548,17 @@ T                         isRelativistic
 If it is true, the test particle velocity update will be relativistic.
 </command>
 
+<command name="JACOBIAN"
+	 alias="JACOBIAN_FLEKS0,JACOBIAN_FLEKS1,JACOBIAN_FLEKS2"
+	 multiple="T">
+  <parameter name="use_grad_center_to_node_jacobian" type="logical" default="F"/>
+
+#JACOBIAN
+F                         use_grad_center_to_node_jacobian
+
+If it is true, the Jacobian will be calculated by calling grad_center_to_node.
+</command>
+
 </commandgroup>
 
 <commandgroup name="Inital and boundary conditions">

--- a/include/TestParticles.h
+++ b/include/TestParticles.h
@@ -156,6 +156,8 @@ private:
   std::vector<PID> vIDs;
 
   Regions tpRegions;
+
+  bool use_grad_center_to_node_jacobian_ = false;
 };
 
 #endif


### PR DESCRIPTION
Still WIP.

This commit introduces a new method for calculating the Jacobian of the magnetic field for test particles. The new method calculates the gradient of the cell-centered magnetic field by calling `grad_center_to_node` for each of its components.

A new option, `use_grad_center_to_node_jacobian`, has been added to `PARAM.XML` to allow switching between the original and the new calculation methods at runtime.

The implementation details are as follows:
- A new `JACOBIAN` command group is added to `PARAM.XML`.
- The `TestParticles` class now has a new member variable to store the selected Jacobian calculation method.
- The new logic is implemented in `TestParticles::move_and_save_charged_particles`, where the cell-centered magnetic field is obtained from the `FluidInterface`, and its gradient is computed at the nodes before the particle loop.
- The calculated gradient is then interpolated to the particle's position.