### PR TITLE
Add wave tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ src/.build_mode
 PC/
 PostProc.pl
 summary.md
+performance_summary.md

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,11 @@ CONVERTER: bin
 	$(call set_build_mode,STANDALONE,standalone)
 	$(STANDALONE_SRC_MAKE) CONVERTER
 
+PIDL:
+	$(call prepare_standalone)
+	$(MAKE) -C $(SHARE_SRC) PIDL
+
+
 rundir:
 	mkdir -p ${RUNDIR}/${COMPONENT}
 	(cd ${RUNDIR}/${COMPONENT}; \

--- a/PARAM.XML
+++ b/PARAM.XML
@@ -1194,7 +1194,7 @@ none            waveType
 0.0             waveAngle
 
 Initialize wave perturbation tests (adiabatic hydrodynamic or MHD waves).
-waveType can be: sound, fast, alfven, slow.
+waveType can be: sound, fast, alfven, slow, anisotropic.
 </command>
 
 

--- a/PARAM.XML
+++ b/PARAM.XML
@@ -1184,17 +1184,20 @@ It will set the initial conditions for a specific test case.
 	 alias="WAVE_FLEKS0,WAVE_FLEKS1,WAVE_FLEKS2" multiple="T">
   <parameter name="waveType" type="string" default="none"/>
   <parameter name="waveAmp" type="real" default="1.0e-4"/>
-  <parameter name="waveLength" type="real" default="1.0"/>
-  <parameter name="waveAngle" type="real" default="0.0"/>
+  <parameter name="LambdaX" type="real" default="-1.0"/>
+  <parameter name="LambdaY" type="real" default="-1.0"/>
+  <parameter name="LambdaZ" type="real" default="-1.0"/>
 
 #WAVE
 none            waveType
 1.0e-4          waveAmp
-1.0             waveLength
-0.0             waveAngle
+-1.0            LambdaX
+-1.0            LambdaY
+-1.0            LambdaZ
 
-Initialize wave perturbation tests (adiabatic hydrodynamic or MHD waves).
-waveType can be: sound, fast, alfven, slow, anisotropic.
+Initialize wave perturbation tests (adiabatic hydrodynamic, MHD, or Langmuir waves) with arbitrary wave vector orientation.
+waveType can be: sound, fast, alfven, slow, anisotropic, langmuir.
+LambdaX, LambdaY, LambdaZ specify wavelengths along each axis. A negative or zero wavelength sets the corresponding wave number component to zero.
 </command>
 
 

--- a/PARAM.XML
+++ b/PARAM.XML
@@ -1180,6 +1180,24 @@ Beam		testCase
 It will set the initial conditions for a specific test case.
 </command>
 
+<command name="WAVE"
+	 alias="WAVE_FLEKS0,WAVE_FLEKS1,WAVE_FLEKS2" multiple="T">
+  <parameter name="waveType" type="string" default="none"/>
+  <parameter name="waveAmp" type="real" default="1.0e-4"/>
+  <parameter name="waveLength" type="real" default="1.0"/>
+  <parameter name="waveAngle" type="real" default="0.0"/>
+
+#WAVE
+none            waveType
+1.0e-4          waveAmp
+1.0             waveLength
+0.0             waveAngle
+
+Initialize wave perturbation tests (adiabatic hydrodynamic or MHD waves).
+waveType can be: sound, fast, alfven, slow.
+</command>
+
+
 <command name="PERIODICITY">
   <parameter name="isPeriodicX" type="logical" default="F" />
   <parameter name="isPeriodicY" type="logical" default="F" />

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -95,6 +95,12 @@ protected:
 
   amrex::Vector<double> uniformState;
 
+  // Wave initialization parameters
+  std::string waveType = "none";
+  double waveAmp = 1.0e-4;
+  double waveLength = 1.0;
+  double waveAngle = 0.0;
+
   // Length in BATSRUS normalized unit -> Si
   double MhdNo2SiL;
 

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -95,12 +95,19 @@ protected:
 
   amrex::Vector<double> uniformState;
 
-  // Wave initialization parameters
-  std::string waveType = "none";
-  double waveAmp = 1.0e-4;
-  double LambdaX = -1.0;
-  double LambdaY = -1.0;
-  double LambdaZ = -1.0;
+  public:
+    struct WaveInfo {
+      std::string nameVar;
+      double width = 0.0;
+      double amplitude = 0.0;
+      double lambdaX = -1.0;
+      double lambdaY = -1.0;
+      double lambdaZ = -1.0;
+      double phase = 0.0;
+      int exponent = 1;
+    };
+  protected:
+    std::vector<WaveInfo> waveInfos;
 
   // Length in BATSRUS normalized unit -> Si
   double MhdNo2SiL;

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -98,8 +98,9 @@ protected:
   // Wave initialization parameters
   std::string waveType = "none";
   double waveAmp = 1.0e-4;
-  double waveLength = 1.0;
-  double waveAngle = 0.0;
+  double LambdaX = -1.0;
+  double LambdaY = -1.0;
+  double LambdaZ = -1.0;
 
   // Length in BATSRUS normalized unit -> Si
   double MhdNo2SiL;

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -95,19 +95,20 @@ protected:
 
   amrex::Vector<double> uniformState;
 
-  public:
-    struct WaveInfo {
-      std::string nameVar;
-      double width = 0.0;
-      double amplitude = 0.0;
-      double lambdaX = -1.0;
-      double lambdaY = -1.0;
-      double lambdaZ = -1.0;
-      double phase = 0.0;
-      int exponent = 1;
-    };
-  protected:
-    std::vector<WaveInfo> waveInfos;
+public:
+  struct WaveInfo {
+    std::string nameVar;
+    double width = 0.0;
+    double amplitude = 0.0;
+    double lambdaX = -1.0;
+    double lambdaY = -1.0;
+    double lambdaZ = -1.0;
+    double phase = 0.0;
+    int exponent = 1;
+  };
+
+protected:
+  std::vector<WaveInfo> waveInfos;
 
   // Length in BATSRUS normalized unit -> Si
   double MhdNo2SiL;

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -123,7 +123,9 @@ void Domain::init(double time, const int iDomain,
       pic->set_base_grid(BoxArray(centerBox));
 
       fi->regrid(fi->get_base_grid(), nullptr);
-      pic->regrid(pic->get_base_grid(), nullptr);
+      pic->regrid(pic->get_base_grid(), fi.get());
+      if (pt)
+        pt->regrid(fi->boxArray(0), fi.get());
     }
 
     if (stateOH)
@@ -913,7 +915,8 @@ void Domain::read_param(const bool readGridInfo) {
         pt->read_param(command, param);
     } else if (command == "#NORMALIZATION" || command == "#SCALINGFACTOR" ||
                command == "#BODYSIZE" || command == "#PLASMA" ||
-               command == "#UNIFORMSTATE" || command == "#FLUIDVARNAMES") {
+               command == "#UNIFORMSTATE" || command == "#FLUIDVARNAMES" ||
+               command == "#WAVE") {
       fi->read_param(command, param);
     } else if (command == "#LOADBALANCE") {
       std::string strategy;

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -877,11 +877,16 @@ void FluidInterface::set_node_fluid() {
     bool hasRho0 = false;
     bool hasRho1 = false;
     for (const auto& wave : waveInfos) {
-      if (str_eq_det(wave.nameVar, "ppar")) isAnisotropic = true;
-      if (str_eq_det(wave.nameVar, "ex")) isLangmuir = true;
-      if (wave.nameVar == "rho0" || wave.nameVar == "rho_e") hasRho0 = true;
-      if (wave.nameVar == "rho1" || wave.nameVar == "rho_i") hasRho1 = true;
-      if (str_eq_det(wave.nameVar, "by") || str_eq_det(wave.nameVar, "bz")) isMHD = true;
+      if (str_eq_det(wave.nameVar, "ppar"))
+        isAnisotropic = true;
+      if (str_eq_det(wave.nameVar, "ex"))
+        isLangmuir = true;
+      if (wave.nameVar == "rho0" || wave.nameVar == "rho_e")
+        hasRho0 = true;
+      if (wave.nameVar == "rho1" || wave.nameVar == "rho_i")
+        hasRho1 = true;
+      if (str_eq_det(wave.nameVar, "by") || str_eq_det(wave.nameVar, "bz"))
+        isMHD = true;
     }
 
     if (hasRho0 && hasRho1) {
@@ -1073,7 +1078,8 @@ void FluidInterface::set_node_fluid() {
           Real dEy = dEx_w * ex_y + dEy_w * ey_y + dEz_w * ez_y;
           Real dEz = dEx_w * ex_z + dEy_w * ey_z + dEz_w * ez_z;
 
-          // Apply background + perturbations to all fluids/species, scaled by mass
+          // Apply background + perturbations to all fluids/species, scaled by
+          // mass
           for (int iFluid = 0; iFluid < nFluid; ++iFluid) {
             const Real m = MoMi_S[iFluid];
             Real rho = (rho0 + dRho[iFluid]) * m;
@@ -1083,8 +1089,10 @@ void FluidInterface::set_node_fluid() {
 
             Real species_p0 = p0;
             if (isIAW) {
-              if (iFluid == 0) species_p0 = 1.0;
-              else species_p0 = 0.05;
+              if (iFluid == 0)
+                species_p0 = 1.0;
+              else
+                species_p0 = 0.05;
             }
             Real p = (species_p0 + dP[iFluid]) * m;
 

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -422,8 +422,9 @@ void FluidInterface::read_param(const std::string& command, ReadParam& param) {
   } else if (command == "#WAVE") {
     param.read_var("waveType", waveType);
     param.read_var("waveAmp", waveAmp);
-    param.read_var("waveLength", waveLength);
-    param.read_var("waveAngle", waveAngle);
+    param.read_var("LambdaX", LambdaX);
+    param.read_var("LambdaY", LambdaY);
+    param.read_var("LambdaZ", LambdaZ);
   } else if (command == "#SCALINGFACTOR") {
     param.read_var("scaling", ScalingFactor);
   } else if (command == "#BODYSIZE") {
@@ -780,21 +781,59 @@ void FluidInterface::set_node_fluid() {
     Real rho0 = 1.0;
     Real p0 = isColdPlasma ? 0.0 : 0.6;
     Real ux0 = 0.0, uy0 = 0.0, uz0 = 0.0;
-    Real bx0 = 0.0, by0 = 0.0, bz0 = 0.0;
 
+    // Parse wave vector based on LambdaX, LambdaY, LambdaZ
+    Real kx = (LambdaX > 0.0) ? (2.0 * dPI / LambdaX) : 0.0;
+    Real ky = (LambdaY > 0.0) ? (2.0 * dPI / LambdaY) : 0.0;
+    Real kz = (LambdaZ > 0.0) ? (2.0 * dPI / LambdaZ) : 0.0;
+    Real k_mag = sqrt(kx * kx + ky * ky + kz * kz);
+
+    if (k_mag == 0.0) {
+      // Default fallback if no valid wavelength is set: wave along X with wavelength 1.0
+      kx = 2.0 * dPI;
+      k_mag = kx;
+    }
+
+    Real nx = kx / k_mag;
+    Real ny = ky / k_mag;
+    Real nz = kz / k_mag;
+
+    // Build 3D orthonormal basis vectors ex', ey', ez' for wave coordinate system
+    Real ex_x = nx, ex_y = ny, ex_z = nz;
+    Real ey_x = 0.0, ey_y = 0.0, ey_z = 0.0;
+    Real ez_x = 0.0, ez_y = 0.0, ez_z = 0.0;
+
+    if (std::abs(ex_x) < 1.0e-10 && std::abs(ex_y) < 1.0e-10) {
+      ey_y = 1.0;
+      ez_x = -ex_z;
+    } else {
+      Real norm = sqrt(ex_x * ex_x + ex_y * ex_y);
+      ey_x = -ex_y / norm;
+      ey_y = ex_x / norm;
+      ey_z = 0.0;
+
+      ez_x = ex_y * ey_z - ex_z * ey_y;
+      ez_y = ex_z * ey_x - ex_x * ey_z;
+      ez_z = ex_x * ey_y - ex_y * ey_x;
+    }
+
+    Real bx0_wave = 0.0, by0_wave = 0.0, bz0_wave = 0.0;
     if (waveType == "langmuir") {
       // Langmuir wave background is 0
     } else if (waveType == "anisotropic") {
       rho0 = 1.0;
       p0 = 4.5e-4;
-      bx0 = 0.0;
-      by0 = 0.04;
-      bz0 = 0.0;
+      by0_wave = 0.04;
     } else if (waveType != "sound") {
-      bx0 = 1.0;
-      by0 = sqrt(2.0);
-      bz0 = 0.5;
+      bx0_wave = 1.0;
+      by0_wave = sqrt(2.0);
+      bz0_wave = 0.5;
     }
+
+    // Rotate background magnetic field from wave frame to simulation frame
+    Real bx0 = bx0_wave * ex_x + by0_wave * ey_x + bz0_wave * ez_x;
+    Real by0 = bx0_wave * ex_y + by0_wave * ey_y + bz0_wave * ez_y;
+    Real bz0 = bx0_wave * ex_z + by0_wave * ez_z + bz0_wave * ez_z;
 
     for (int iLev = 0; iLev < n_lev(); iLev++) {
       const auto& dx = Geom(iLev).CellSize();
@@ -806,75 +845,88 @@ void FluidInterface::set_node_fluid() {
 
         ParallelFor(box, [=](int i, int j, int k) noexcept {
           const Real x = i * dx[ix_] + plo[ix_];
-          const Real k_wave = 2.0 * dPI / waveLength;
-          const Real phase = k_wave * x;
+          const Real y = j * dx[iy_] + plo[iy_];
+          const Real z = k * dx[iz_] + plo[iz_];
+          const Real phase = kx * x + ky * y + kz * z;
           const Real S = sin(phase);
 
-          // 2. Set wave eigenfunctions/perturbations
-          Real dRho = 0.0, dUx = 0.0, dUy = 0.0, dUz = 0.0, dP = 0.0;
-          Real dBx = 0.0, dBy = 0.0, dBz = 0.0;
+          // 2. Set wave eigenfunctions/perturbations in wave coordinate system
+          Real dRho = 0.0, dUx_w = 0.0, dUy_w = 0.0, dUz_w = 0.0, dP = 0.0;
+          Real dBx_w = 0.0, dBy_w = 0.0, dBz_w = 0.0;
 
           if (waveType == "sound") {
             dRho = 1.0 * S;
-            dUx = -1.0 * S;
+            dUx_w = -1.0 * S;
             dP = 1.0 * S;
           } else if (waveType == "langmuir") {
             // Handled specifically inside the species and field assignments
           } else if (waveType == "fast") {
             dRho = 0.4472135954999580 * S;
-            dUx = -0.8944271909999160 * S;
-            dUy = 0.4216370213557840 * S;
-            dUz = 0.1490711984999860 * S;
+            dUx_w = -0.8944271909999160 * S;
+            dUy_w = 0.4216370213557840 * S;
+            dUz_w = 0.1490711984999860 * S;
             dP = 0.4472135954999580 * S;
-            dBy = 0.8432740427115680 * S;
-            dBz = 0.2981423969999720 * S;
+            dBy_w = 0.8432740427115680 * S;
+            dBz_w = 0.2981423969999720 * S;
           } else if (waveType == "alfven") {
-            dUy = -0.3333333333333333 * S;
-            dUz = 0.9428090415820634 * S;
-            dBy = -0.3333333333333333 * S;
-            dBz = 0.9428090415820634 * S;
+            dUy_w = -0.3333333333333333 * S;
+            dUz_w = 0.9428090415820634 * S;
+            dBy_w = -0.3333333333333333 * S;
+            dBz_w = 0.9428090415820634 * S;
           } else if (waveType == "slow") {
             dRho = 0.8944271909999159 * S;
-            dUx = -0.4472135954999579 * S;
-            dUy = -0.8432740427115680 * S;
-            dUz = -0.2981423969999720 * S;
+            dUx_w = -0.4472135954999579 * S;
+            dUy_w = -0.8432740427115680 * S;
+            dUz_w = -0.2981423969999720 * S;
             dP = 0.8944271909999159 * S;
-            dBy = -0.4216370213557841 * S;
-            dBz = -0.1490711984999860 * S;
+            dBy_w = -0.4216370213557841 * S;
+            dBz_w = -0.1490711984999860 * S;
           } else if (waveType == "anisotropic") {
             const Real B0 = 0.04;
             const Real V_f = sqrt((B0 * B0 + 2.0 * p0) / rho0);
             const Real gamma = 5.0 / 3.0;
             dRho = 1.0 * S;
-            dUx = V_f * S;
+            dUx_w = V_f * S;
             dP = 0.6 * gamma * S;
-            dBy = B0 * S;
+            dBy_w = B0 * S;
           }
 
-          // Apply background + perturbations to all fluids/species, scaled by
-          // mass
+          // Rotate perturbations to simulation/grid frame
+          Real dUx = dUx_w * ex_x + dUy_w * ey_x + dUz_w * ez_x;
+          Real dUy = dUx_w * ex_y + dUy_w * ey_y + dUz_w * ez_y;
+          Real dUz = dUx_w * ex_z + dUy_w * ey_z + dUz_w * ez_z;
+
+          Real dBx = dBx_w * ex_x + dBy_w * ey_x + dBz_w * ez_x;
+          Real dBy = dBx_w * ex_y + dBy_w * ey_y + dBz_w * ez_y;
+          Real dBz = dBx_w * ex_z + dBy_w * ez_z + dBz_w * ez_z;
+
+          // Apply background + perturbations to all fluids/species, scaled by mass
           for (int iFluid = 0; iFluid < nFluid; ++iFluid) {
             const Real m = MoMi_S[iFluid];
             Real rho = rho0 * m;
             Real ux = ux0;
+            Real uy = uy0;
+            Real uz = uz0;
             Real p = p0 * m;
 
             if (waveType == "langmuir") {
               if (iFluid == 0) { // Electrons
-                rho = (rho0 + waveAmp * cos(x)) * m;
+                rho = (rho0 + waveAmp * cos(phase)) * m;
               }
               p = 0.0; // Cold plasma
             } else {
               rho = (rho0 + waveAmp * dRho) * m;
               const Real dP_scaled = dP * (p0 / 0.6);
               ux = ux0 + waveAmp * dUx;
+              uy = uy0 + waveAmp * dUy;
+              uz = uz0 + waveAmp * dUz;
               p = (p0 + waveAmp * dP_scaled) * m;
             }
 
             arr(i, j, k, iRho_I[iFluid]) = rho;
             arr(i, j, k, iRhoUx_I[iFluid]) = rho * ux;
-            arr(i, j, k, iRhoUy_I[iFluid]) = rho * (uy0 + waveAmp * dUy);
-            arr(i, j, k, iRhoUz_I[iFluid]) = rho * (uz0 + waveAmp * dUz);
+            arr(i, j, k, iRhoUy_I[iFluid]) = rho * uy;
+            arr(i, j, k, iRhoUz_I[iFluid]) = rho * uz;
             arr(i, j, k, iP_I[iFluid]) = p;
 
             if (iPpar_I[iFluid] >= 0) {
@@ -894,9 +946,10 @@ void FluidInterface::set_node_fluid() {
           // Apply background + perturbations to electric fields if defined
           if (iEx >= 0 && iEy >= 0 && iEz >= 0) {
             if (waveType == "langmuir") {
-              arr(i, j, k, iEx) = -waveAmp * 4.0 * dPI * sin(x);
-              arr(i, j, k, iEy) = 0.0;
-              arr(i, j, k, iEz) = 0.0;
+              Real E_amp = -waveAmp * 4.0 * dPI / k_mag;
+              arr(i, j, k, iEx) = nx * E_amp * sin(phase);
+              arr(i, j, k, iEy) = ny * E_amp * sin(phase);
+              arr(i, j, k, iEz) = nz * E_amp * sin(phase);
             } else {
               const Real ux = ux0 + waveAmp * dUx;
               const Real uy = uy0 + waveAmp * dUy;

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -768,13 +768,14 @@ void FluidInterface::set_node_fluid() {
     if (uniformState.size() > 4) {
       isColdPlasma = (uniformState[4] == 0.0);
     }
-
     Real rho0 = 1.0;
     Real p0 = isColdPlasma ? 0.0 : 0.6;
     Real ux0 = 0.0, uy0 = 0.0, uz0 = 0.0;
     Real bx0 = 0.0, by0 = 0.0, bz0 = 0.0;
 
-    if (waveType != "sound") {
+    if (waveType == "langmuir") {
+      // Langmuir wave background is 0
+    } else if (waveType != "sound") {
       bx0 = 1.0;
       by0 = sqrt(2.0);
       bz0 = 0.5;
@@ -802,6 +803,8 @@ void FluidInterface::set_node_fluid() {
             dRho = 1.0 * S;
             dUx = -1.0 * S;
             dP = 1.0 * S;
+          } else if (waveType == "langmuir") {
+            // Handled specifically inside the species and field assignments
           } else if (waveType == "fast") {
             dRho = 0.4472135954999580 * S;
             dUx = -0.8944271909999160 * S;
@@ -829,17 +832,27 @@ void FluidInterface::set_node_fluid() {
           // mass
           for (int iFluid = 0; iFluid < nFluid; ++iFluid) {
             const Real m = MoMi_S[iFluid];
-            const Real rho = (rho0 + waveAmp * dRho) * m;
+            Real rho = rho0 * m;
+            Real ux = ux0;
+            Real p = p0 * m;
 
-            // Physically scale pressure perturbation by background pressure
-            // ratio
-            const Real dP_scaled = dP * (p0 / 0.6);
+            if (waveType == "langmuir") {
+              if (iFluid == 0) { // Electrons
+                rho = (rho0 + 0.02 * cos(x)) * m;
+              }
+              p = 0.0; // Cold plasma
+            } else {
+              rho = (rho0 + waveAmp * dRho) * m;
+              const Real dP_scaled = dP * (p0 / 0.6);
+              ux = ux0 + waveAmp * dUx;
+              p = (p0 + waveAmp * dP_scaled) * m;
+            }
 
             arr(i, j, k, iRho_I[iFluid]) = rho;
-            arr(i, j, k, iRhoUx_I[iFluid]) = rho * (ux0 + waveAmp * dUx);
+            arr(i, j, k, iRhoUx_I[iFluid]) = rho * ux;
             arr(i, j, k, iRhoUy_I[iFluid]) = rho * (uy0 + waveAmp * dUy);
             arr(i, j, k, iRhoUz_I[iFluid]) = rho * (uz0 + waveAmp * dUz);
-            arr(i, j, k, iP_I[iFluid]) = (p0 + waveAmp * dP_scaled) * m;
+            arr(i, j, k, iP_I[iFluid]) = p;
           }
 
           // Apply background + perturbations to magnetic fields
@@ -849,13 +862,19 @@ void FluidInterface::set_node_fluid() {
 
           // Apply background + perturbations to electric fields if defined
           if (iEx >= 0 && iEy >= 0 && iEz >= 0) {
-            const Real dux = waveAmp * dUx;
-            const Real duy = waveAmp * dUy;
-            const Real duz = waveAmp * dUz;
+            if (waveType == "langmuir") {
+              arr(i, j, k, iEx) = -0.02 * sin(x);
+              arr(i, j, k, iEy) = 0.0;
+              arr(i, j, k, iEz) = 0.0;
+            } else {
+              const Real ux = ux0 + waveAmp * dUx;
+              const Real uy = uy0 + waveAmp * dUy;
+              const Real uz = uz0 + waveAmp * dUz;
 
-            arr(i, j, k, iEx) = -(duy * bz0 - duz * by0);
-            arr(i, j, k, iEy) = -(duz * bx0 - dux * bz0);
-            arr(i, j, k, iEz) = -(dux * by0 - duy * bx0);
+              arr(i, j, k, iEx) = -(uy * bz0 - uz * by0);
+              arr(i, j, k, iEy) = -(uz * bx0 - ux * bz0);
+              arr(i, j, k, iEz) = -(ux * by0 - uy * bx0);
+            }
           }
         });
       }
@@ -963,21 +982,61 @@ void FluidInterface::convert_moment_to_velocity(bool phyNodeOnly, bool doWarn) {
 
       ParallelFor(box, [&](int i, int j, int k) noexcept {
         if (useMultiSpecies) {
+          const bool isStandalone = (iRho_I.size() == nS);
           double Rhot = 0;
-          for (int iIon = 0; iIon < nIon; ++iIon) {
-            // Rho = sum(Rhoi) + Rhoe;
-            Rhot +=
-                arr(i, j, k, iRho_I[iIon]) * (1 + MoMi_S[0] / MoMi_S[iIon + 1]);
-          } // iIon
-
-          if (Rhot > 0) {
-            arr(i, j, k, iUx_I[0]) /= Rhot;
-            arr(i, j, k, iUy_I[0]) /= Rhot;
-            arr(i, j, k, iUz_I[0]) /= Rhot;
+          if (isStandalone) {
+            // Standalone mode: iRho_I has size nS (electrons at index 0, ions starting at index 1)
+            double Rhoe = arr(i, j, k, iRho_I[0]);
+            double Rhoi_sum = 0;
+            for (int iIon = 0; iIon < nIon; ++iIon) {
+              Rhoi_sum += arr(i, j, k, iRho_I[iIon + 1]);
+            }
+            Rhot = Rhoi_sum + Rhoe;
           } else {
-            arr(i, j, k, iUx_I[0]) = 0;
-            arr(i, j, k, iUy_I[0]) = 0;
-            arr(i, j, k, iUz_I[0]) = 0;
+            // SWMF coupling mode: iRho_I only contains ion densities
+            for (int iIon = 0; iIon < nIon; ++iIon) {
+              Rhot +=
+                  arr(i, j, k, iRho_I[iIon]) * (1 + MoMi_S[0] / MoMi_S[iIon + 1]);
+            } // iIon
+          }
+
+          if (isStandalone) {
+            double Rhoe = arr(i, j, k, iRho_I[0]);
+            if (Rhoe > 0) {
+              arr(i, j, k, iUx_I[0]) /= Rhoe;
+              arr(i, j, k, iUy_I[0]) /= Rhoe;
+              arr(i, j, k, iUz_I[0]) /= Rhoe;
+            } else {
+              arr(i, j, k, iUx_I[0]) = 0;
+              arr(i, j, k, iUy_I[0]) = 0;
+              arr(i, j, k, iUz_I[0]) = 0;
+            }
+          } else {
+            if (Rhot > 0) {
+              arr(i, j, k, iUx_I[0]) /= Rhot;
+              arr(i, j, k, iUy_I[0]) /= Rhot;
+              arr(i, j, k, iUz_I[0]) /= Rhot;
+            } else {
+              arr(i, j, k, iUx_I[0]) = 0;
+              arr(i, j, k, iUy_I[0]) = 0;
+              arr(i, j, k, iUz_I[0]) = 0;
+            }
+          }
+
+          // Convert ion momenta to velocities in standalone mode
+          if (isStandalone) {
+            for (int iIon = 0; iIon < nIon; ++iIon) {
+              const double& rho = arr(i, j, k, iRho_I[iIon + 1]);
+              if (rho > 0) {
+                arr(i, j, k, iUx_I[iIon + 1]) /= rho;
+                arr(i, j, k, iUy_I[iIon + 1]) /= rho;
+                arr(i, j, k, iUz_I[iIon + 1]) /= rho;
+              } else {
+                arr(i, j, k, iUx_I[iIon + 1]) = 0;
+                arr(i, j, k, iUy_I[iIon + 1]) = 0;
+                arr(i, j, k, iUz_I[iIon + 1]) = 0;
+              }
+            }
           }
         } else {
           for (int iFluid = 0; iFluid < nFluid; ++iFluid) {

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -789,7 +789,8 @@ void FluidInterface::set_node_fluid() {
     Real k_mag = sqrt(kx * kx + ky * ky + kz * kz);
 
     if (k_mag == 0.0) {
-      // Default fallback if no valid wavelength is set: wave along X with wavelength 1.0
+      // Default fallback if no valid wavelength is set: wave along X with
+      // wavelength 1.0
       kx = 2.0 * dPI;
       k_mag = kx;
     }
@@ -798,7 +799,8 @@ void FluidInterface::set_node_fluid() {
     Real ny = ky / k_mag;
     Real nz = kz / k_mag;
 
-    // Build 3D orthonormal basis vectors ex', ey', ez' for wave coordinate system
+    // Build 3D orthonormal basis vectors ex', ey', ez' for wave coordinate
+    // system
     Real ex_x = nx, ex_y = ny, ex_z = nz;
     Real ey_x = 0.0, ey_y = 0.0, ey_z = 0.0;
     Real ez_x = 0.0, ez_y = 0.0, ez_z = 0.0;
@@ -900,7 +902,8 @@ void FluidInterface::set_node_fluid() {
           Real dBy = dBx_w * ex_y + dBy_w * ey_y + dBz_w * ez_y;
           Real dBz = dBx_w * ex_z + dBy_w * ez_z + dBz_w * ez_z;
 
-          // Apply background + perturbations to all fluids/species, scaled by mass
+          // Apply background + perturbations to all fluids/species, scaled by
+          // mass
           for (int iFluid = 0; iFluid < nFluid; ++iFluid) {
             const Real m = MoMi_S[iFluid];
             Real rho = rho0 * m;

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -985,7 +985,8 @@ void FluidInterface::convert_moment_to_velocity(bool phyNodeOnly, bool doWarn) {
           const bool isStandalone = (iRho_I.size() == nS);
           double Rhot = 0;
           if (isStandalone) {
-            // Standalone mode: iRho_I has size nS (electrons at index 0, ions starting at index 1)
+            // Standalone mode: iRho_I has size nS (electrons at index 0, ions
+            // starting at index 1)
             double Rhoe = arr(i, j, k, iRho_I[0]);
             double Rhoi_sum = 0;
             for (int iIon = 0; iIon < nIon; ++iIon) {
@@ -995,8 +996,8 @@ void FluidInterface::convert_moment_to_velocity(bool phyNodeOnly, bool doWarn) {
           } else {
             // SWMF coupling mode: iRho_I only contains ion densities
             for (int iIon = 0; iIon < nIon; ++iIon) {
-              Rhot +=
-                  arr(i, j, k, iRho_I[iIon]) * (1 + MoMi_S[0] / MoMi_S[iIon + 1]);
+              Rhot += arr(i, j, k, iRho_I[iIon]) *
+                      (1 + MoMi_S[0] / MoMi_S[iIon + 1]);
             } // iIon
           }
 

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -861,7 +861,7 @@ void FluidInterface::set_node_fluid() {
 
             if (waveType == "langmuir") {
               if (iFluid == 0) { // Electrons
-                rho = (rho0 + 0.02 * cos(x)) * m;
+                rho = (rho0 + waveAmp * cos(x)) * m;
               }
               p = 0.0; // Cold plasma
             } else {
@@ -894,7 +894,7 @@ void FluidInterface::set_node_fluid() {
           // Apply background + perturbations to electric fields if defined
           if (iEx >= 0 && iEy >= 0 && iEz >= 0) {
             if (waveType == "langmuir") {
-              arr(i, j, k, iEx) = -0.02 * sin(x);
+              arr(i, j, k, iEx) = -waveAmp * 4.0 * dPI * sin(x);
               arr(i, j, k, iEy) = 0.0;
               arr(i, j, k, iEz) = 0.0;
             } else {

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -195,6 +195,9 @@ void FluidInterface::post_process_param(bool receiveICOnly) {
       iJz = iJx + 2;
     }
   } else {
+    if (waveType == "anisotropic") {
+      useAnisoP = true;
+    }
     // Assume the variables are set through command #UNIFORMSTATE
     int idx = 0;
     for (int i = 0; i < nS; ++i) {
@@ -206,6 +209,12 @@ void FluidInterface::post_process_param(bool receiveICOnly) {
       varNames.push_back("uy" + std::to_string(i));
       iUz_I[i] = idx++;
       varNames.push_back("uz" + std::to_string(i));
+      if (useAnisoP) {
+        iPpar_I[i] = idx++;
+        varNames.push_back("ppar" + std::to_string(i));
+      } else {
+        iPpar_I[i] = -1;
+      }
       iP_I[i] = idx++;
       varNames.push_back("p" + std::to_string(i));
     }
@@ -775,6 +784,12 @@ void FluidInterface::set_node_fluid() {
 
     if (waveType == "langmuir") {
       // Langmuir wave background is 0
+    } else if (waveType == "anisotropic") {
+      rho0 = 1.0;
+      p0 = 4.5e-4;
+      bx0 = 0.0;
+      by0 = 0.04;
+      bz0 = 0.0;
     } else if (waveType != "sound") {
       bx0 = 1.0;
       by0 = sqrt(2.0);
@@ -826,6 +841,14 @@ void FluidInterface::set_node_fluid() {
             dP = 0.8944271909999159 * S;
             dBy = -0.4216370213557841 * S;
             dBz = -0.1490711984999860 * S;
+          } else if (waveType == "anisotropic") {
+            const Real B0 = 0.04;
+            const Real V_f = sqrt((B0 * B0 + 2.0 * p0) / rho0);
+            const Real gamma = 5.0 / 3.0;
+            dRho = 1.0 * S;
+            dUx = V_f * S;
+            dP = 0.6 * gamma * S;
+            dBy = B0 * S;
           }
 
           // Apply background + perturbations to all fluids/species, scaled by
@@ -853,6 +876,14 @@ void FluidInterface::set_node_fluid() {
             arr(i, j, k, iRhoUy_I[iFluid]) = rho * (uy0 + waveAmp * dUy);
             arr(i, j, k, iRhoUz_I[iFluid]) = rho * (uz0 + waveAmp * dUz);
             arr(i, j, k, iP_I[iFluid]) = p;
+
+            if (iPpar_I[iFluid] >= 0) {
+              if (waveType == "anisotropic") {
+                arr(i, j, k, iPpar_I[iFluid]) = (p0 * (1.0 + waveAmp * S)) * m;
+              } else {
+                arr(i, j, k, iPpar_I[iFluid]) = p;
+              }
+            }
           }
 
           // Apply background + perturbations to magnetic fields

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -847,6 +847,7 @@ void FluidInterface::set_node_fluid() {
     bool isAnisotropic = false;
     bool isLangmuir = false;
     bool isMHD = false;
+    bool isIAW = false;
 
     auto str_eq_det = [](const std::string& a, const char* b) {
       char var[20] = { 0 };
@@ -873,16 +874,22 @@ void FluidInterface::set_node_fluid() {
       return true;
     };
 
+    bool hasRho0 = false;
+    bool hasRho1 = false;
     for (const auto& wave : waveInfos) {
-      if (str_eq_det(wave.nameVar, "ppar"))
-        isAnisotropic = true;
-      if (str_eq_det(wave.nameVar, "ex") || str_eq_det(wave.nameVar, "rho")) {
-        if (str_eq_det(wave.nameVar, "ex") || wave.nameVar == "rho0") {
-          isLangmuir = true;
-        }
-      }
-      if (str_eq_det(wave.nameVar, "by") || str_eq_det(wave.nameVar, "bz"))
-        isMHD = true;
+      if (str_eq_det(wave.nameVar, "ppar")) isAnisotropic = true;
+      if (str_eq_det(wave.nameVar, "ex")) isLangmuir = true;
+      if (wave.nameVar == "rho0" || wave.nameVar == "rho_e") hasRho0 = true;
+      if (wave.nameVar == "rho1" || wave.nameVar == "rho_i") hasRho1 = true;
+      if (str_eq_det(wave.nameVar, "by") || str_eq_det(wave.nameVar, "bz")) isMHD = true;
+    }
+
+    if (hasRho0 && hasRho1) {
+      isIAW = true;
+    } else if (hasRho0 && isLangmuir) {
+      isLangmuir = true;
+    } else if (hasRho0 && !isMHD && !isAnisotropic) {
+      isLangmuir = true;
     }
 
     if (isAnisotropic) {
@@ -890,6 +897,8 @@ void FluidInterface::set_node_fluid() {
       by0_wave = 0.04;
     } else if (isLangmuir) {
       p0 = 0.0;
+    } else if (isIAW) {
+      p0 = 1.0;
     } else if (isMHD) {
       bx0_wave = 1.0;
       by0_wave = sqrt(2.0);
@@ -1064,15 +1073,20 @@ void FluidInterface::set_node_fluid() {
           Real dEy = dEx_w * ex_y + dEy_w * ey_y + dEz_w * ez_y;
           Real dEz = dEx_w * ex_z + dEy_w * ey_z + dEz_w * ez_z;
 
-          // Apply background + perturbations to all fluids/species, scaled by
-          // mass
+          // Apply background + perturbations to all fluids/species, scaled by mass
           for (int iFluid = 0; iFluid < nFluid; ++iFluid) {
             const Real m = MoMi_S[iFluid];
             Real rho = (rho0 + dRho[iFluid]) * m;
             Real ux = ux0 + dUx[iFluid];
             Real uy = uy0 + dUy[iFluid];
             Real uz = uz0 + dUz[iFluid];
-            Real p = (p0 + dP[iFluid]) * m;
+
+            Real species_p0 = p0;
+            if (isIAW) {
+              if (iFluid == 0) species_p0 = 1.0;
+              else species_p0 = 0.05;
+            }
+            Real p = (species_p0 + dP[iFluid]) * m;
 
             arr(i, j, k, iRho_I[iFluid]) = rho;
             arr(i, j, k, iRhoUx_I[iFluid]) = rho * ux;

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -844,6 +844,17 @@ void FluidInterface::set_node_fluid() {
           arr(i, j, k, iBx) = bx0 + waveAmp * dBx;
           arr(i, j, k, iBy) = by0 + waveAmp * dBy;
           arr(i, j, k, iBz) = bz0 + waveAmp * dBz;
+
+          // Apply background + perturbations to electric fields if defined
+          if (iEx >= 0 && iEy >= 0 && iEz >= 0) {
+            const Real dux = waveAmp * dUx;
+            const Real duy = waveAmp * dUy;
+            const Real duz = waveAmp * dUz;
+
+            arr(i, j, k, iEx) = -(duy * bz0 - duz * by0);
+            arr(i, j, k, iEy) = -(duz * bx0 - dux * bz0);
+            arr(i, j, k, iEz) = -(dux * by0 - duy * bx0);
+          }
         });
       }
 

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -195,7 +195,16 @@ void FluidInterface::post_process_param(bool receiveICOnly) {
       iJz = iJx + 2;
     }
   } else {
-    if (waveType == "anisotropic") {
+    bool hasPpar = false;
+    for (const auto& wave : waveInfos) {
+      std::string var = wave.nameVar;
+      std::transform(var.begin(), var.end(), var.begin(), ::tolower);
+      if (var.rfind("ppar", 0) == 0) {
+        hasPpar = true;
+        break;
+      }
+    }
+    if (hasPpar) {
       useAnisoP = true;
     }
     // Assume the variables are set through command #UNIFORMSTATE
@@ -419,12 +428,28 @@ void FluidInterface::read_param(const std::string& command, ReadParam& param) {
   if (command == "#NORMALIZATION") {
     param.read_var("lNorm", lNormSI);
     param.read_var("uNorm", uNormSI);
-  } else if (command == "#WAVE") {
-    param.read_var("waveType", waveType);
-    param.read_var("waveAmp", waveAmp);
-    param.read_var("LambdaX", LambdaX);
-    param.read_var("LambdaY", LambdaY);
-    param.read_var("LambdaZ", LambdaZ);
+  } else if (command == "#WAVE" || command == "#WAVE2" || command == "#WAVE4" || command == "#WAVE6" ||
+             command.rfind("#WAVE_FLEKS", 0) == 0) {
+    WaveInfo info;
+    param.read_var("NameVar", info.nameVar);
+    param.read_var("Width", info.width);
+    param.read_var("Amplitude", info.amplitude);
+    param.read_var("LambdaX", info.lambdaX);
+    param.read_var("LambdaY", info.lambdaY);
+    param.read_var("LambdaZ", info.lambdaZ);
+    param.read_var("Phase", info.phase);
+
+    if (command == "#WAVE6") {
+      info.exponent = 6;
+    } else if (command == "#WAVE4") {
+      info.exponent = 4;
+    } else if (command == "#WAVE2") {
+      info.exponent = 2;
+    } else {
+      info.exponent = 1;
+    }
+
+    waveInfos.push_back(info);
   } else if (command == "#SCALINGFACTOR") {
     param.read_var("scaling", ScalingFactor);
   } else if (command == "#BODYSIZE") {
@@ -772,20 +797,11 @@ void FluidInterface::set_node_fluid() {
   calc_current();
   normalize_fluid_variables();
 
-  if (waveType != "none") {
-    // Check if cold plasma is requested via PARAM.in (T = 0)
-    bool isColdPlasma = false;
-    if (uniformState.size() > 4) {
-      isColdPlasma = (uniformState[4] == 0.0);
-    }
-    Real rho0 = 1.0;
-    Real p0 = isColdPlasma ? 0.0 : 0.6;
-    Real ux0 = 0.0, uy0 = 0.0, uz0 = 0.0;
-
-    // Parse wave vector based on LambdaX, LambdaY, LambdaZ
-    Real kx = (LambdaX > 0.0) ? (2.0 * dPI / LambdaX) : 0.0;
-    Real ky = (LambdaY > 0.0) ? (2.0 * dPI / LambdaY) : 0.0;
-    Real kz = (LambdaZ > 0.0) ? (2.0 * dPI / LambdaZ) : 0.0;
+  if (!waveInfos.empty()) {
+    // Use the wavevector of the first wave command to define the main coordinate rotation.
+    Real kx = (waveInfos[0].lambdaX > 0.0) ? (2.0 * dPI / waveInfos[0].lambdaX) : 0.0;
+    Real ky = (waveInfos[0].lambdaY > 0.0) ? (2.0 * dPI / waveInfos[0].lambdaY) : 0.0;
+    Real kz = (waveInfos[0].lambdaZ > 0.0) ? (2.0 * dPI / waveInfos[0].lambdaZ) : 0.0;
     Real k_mag = sqrt(kx * kx + ky * ky + kz * kz);
 
     if (k_mag == 0.0) {
@@ -819,14 +835,54 @@ void FluidInterface::set_node_fluid() {
       ez_z = ex_x * ey_y - ex_y * ey_x;
     }
 
+    Real rho0 = 1.0;
+    Real p0 = 0.6;
     Real bx0_wave = 0.0, by0_wave = 0.0, bz0_wave = 0.0;
-    if (waveType == "langmuir") {
-      // Langmuir wave background is 0
-    } else if (waveType == "anisotropic") {
-      rho0 = 1.0;
+
+    // Detect wave test type based on waveInfos
+    bool isAnisotropic = false;
+    bool isLangmuir = false;
+    bool isMHD = false;
+
+    auto str_eq_det = [](const std::string& a, const char* b) {
+      char var[20] = {0};
+      for (size_t c = 0; c < a.size() && c < 19; ++c) {
+        char ch = a[c];
+        if (ch >= 'A' && ch <= 'Z') {
+          var[c] = ch - 'A' + 'a';
+        } else {
+          var[c] = ch;
+        }
+      }
+      int len = 0;
+      while (var[len] != '\0') len++;
+      if (len > 0 && var[len - 1] >= '0' && var[len - 1] <= '9') {
+        var[len - 1] = '\0';
+      }
+      int idx = 0;
+      while (var[idx] != '\0' || b[idx] != '\0') {
+        if (var[idx] != b[idx]) return false;
+        idx++;
+      }
+      return true;
+    };
+
+    for (const auto& wave : waveInfos) {
+      if (str_eq_det(wave.nameVar, "ppar")) isAnisotropic = true;
+      if (str_eq_det(wave.nameVar, "ex") || str_eq_det(wave.nameVar, "rho")) {
+        if (str_eq_det(wave.nameVar, "ex") || wave.nameVar == "rho0") {
+          isLangmuir = true;
+        }
+      }
+      if (str_eq_det(wave.nameVar, "by") || str_eq_det(wave.nameVar, "bz")) isMHD = true;
+    }
+
+    if (isAnisotropic) {
       p0 = 4.5e-4;
       by0_wave = 0.04;
-    } else if (waveType != "sound") {
+    } else if (isLangmuir) {
+      p0 = 0.0;
+    } else if (isMHD) {
       bx0_wave = 1.0;
       by0_wave = sqrt(2.0);
       bz0_wave = 0.5;
@@ -836,6 +892,14 @@ void FluidInterface::set_node_fluid() {
     Real bx0 = bx0_wave * ex_x + by0_wave * ey_x + bz0_wave * ez_x;
     Real by0 = bx0_wave * ex_y + by0_wave * ey_y + bz0_wave * ez_y;
     Real bz0 = bx0_wave * ex_z + by0_wave * ez_z + bz0_wave * ez_z;
+
+    Real ux0 = 0.0, uy0 = 0.0, uz0 = 0.0;
+
+    // Copy waveInfos to a local Amrex Vector so it can be captured by lambda
+    amrex::Vector<WaveInfo> waveList;
+    for (const auto& w : waveInfos) {
+      waveList.push_back(w);
+    }
 
     for (int iLev = 0; iLev < n_lev(); iLev++) {
       const auto& dx = Geom(iLev).CellSize();
@@ -849,82 +913,157 @@ void FluidInterface::set_node_fluid() {
           const Real x = i * dx[ix_] + plo[ix_];
           const Real y = j * dx[iy_] + plo[iy_];
           const Real z = k * dx[iz_] + plo[iz_];
-          const Real phase = kx * x + ky * y + kz * z;
-          const Real S = sin(phase);
 
-          // 2. Set wave eigenfunctions/perturbations in wave coordinate system
-          Real dRho = 0.0, dUx_w = 0.0, dUy_w = 0.0, dUz_w = 0.0, dP = 0.0;
+          // Initialize wave-frame perturbations for nS species
+          Real dRho[3] = {0.0};
+          Real dUx_w[3] = {0.0}, dUy_w[3] = {0.0}, dUz_w[3] = {0.0};
+          Real dP[3] = {0.0};
+          Real dPpar[3] = {0.0};
+          bool hasPparPert = false;
+
           Real dBx_w = 0.0, dBy_w = 0.0, dBz_w = 0.0;
+          Real dEx_w = 0.0, dEy_w = 0.0, dEz_w = 0.0;
 
-          if (waveType == "sound") {
-            dRho = 1.0 * S;
-            dUx_w = -1.0 * S;
-            dP = 1.0 * S;
-          } else if (waveType == "langmuir") {
-            // Handled specifically inside the species and field assignments
-          } else if (waveType == "fast") {
-            dRho = 0.4472135954999580 * S;
-            dUx_w = -0.8944271909999160 * S;
-            dUy_w = 0.4216370213557840 * S;
-            dUz_w = 0.1490711984999860 * S;
-            dP = 0.4472135954999580 * S;
-            dBy_w = 0.8432740427115680 * S;
-            dBz_w = 0.2981423969999720 * S;
-          } else if (waveType == "alfven") {
-            dUy_w = -0.3333333333333333 * S;
-            dUz_w = 0.9428090415820634 * S;
-            dBy_w = -0.3333333333333333 * S;
-            dBz_w = 0.9428090415820634 * S;
-          } else if (waveType == "slow") {
-            dRho = 0.8944271909999159 * S;
-            dUx_w = -0.4472135954999579 * S;
-            dUy_w = -0.8432740427115680 * S;
-            dUz_w = -0.2981423969999720 * S;
-            dP = 0.8944271909999159 * S;
-            dBy_w = -0.4216370213557841 * S;
-            dBz_w = -0.1490711984999860 * S;
-          } else if (waveType == "anisotropic") {
-            const Real B0 = 0.04;
-            const Real V_f = sqrt((B0 * B0 + 2.0 * p0) / rho0);
-            const Real gamma = 5.0 / 3.0;
-            dRho = 1.0 * S;
-            dUx_w = V_f * S;
-            dP = 0.6 * gamma * S;
-            dBy_w = B0 * S;
+          // Loop over all #WAVE commands to sum up perturbations
+          for (int iW = 0; iW < waveList.size(); ++iW) {
+            const auto& wave = waveList[iW];
+
+            Real kx_w = (wave.lambdaX > 0.0) ? (2.0 * dPI / wave.lambdaX) : 0.0;
+            Real ky_w = (wave.lambdaY > 0.0) ? (2.0 * dPI / wave.lambdaY) : 0.0;
+            Real kz_w = (wave.lambdaZ > 0.0) ? (2.0 * dPI / wave.lambdaZ) : 0.0;
+            Real k_mag_w = sqrt(kx_w * kx_w + ky_w * ky_w + kz_w * kz_w);
+
+            if (k_mag_w == 0.0) {
+              kx_w = 2.0 * dPI;
+              k_mag_w = kx_w;
+            }
+
+            Real nx_w = kx_w / k_mag_w;
+            Real ny_w = ky_w / k_mag_w;
+            Real nz_w = kz_w / k_mag_w;
+
+            // Check width if specified
+            if (wave.width > 0.0) {
+              Real r_dot_n = x * nx_w + y * ny_w + z * nz_w;
+              if (std::abs(r_dot_n) > wave.width) {
+                continue;
+              }
+            }
+
+            Real phase_w = kx_w * x + ky_w * y + kz_w * z;
+            Real phase_rad = wave.phase * dPI / 180.0;
+            Real term = cos(phase_w + phase_rad);
+            Real S = pow(term, wave.exponent);
+
+            // Match variable name (case insensitive manually or via check)
+            char var[20] = {0};
+            for (size_t c = 0; c < wave.nameVar.size() && c < 19; ++c) {
+              char ch = wave.nameVar[c];
+              if (ch >= 'A' && ch <= 'Z') {
+                var[c] = ch - 'A' + 'a';
+              } else {
+                var[c] = ch;
+              }
+            }
+
+            // Extract trailing digit if any
+            int len = 0;
+            while (var[len] != '\0') {
+              len++;
+            }
+            int targetS = -1;
+            if (len > 0 && var[len - 1] >= '0' && var[len - 1] <= '9') {
+              targetS = var[len - 1] - '0';
+              var[len - 1] = '\0';
+            }
+
+            // Map string to variables
+            auto str_eq = [](const char* a, const char* b) {
+              int idx = 0;
+              while (a[idx] != '\0' || b[idx] != '\0') {
+                if (a[idx] != b[idx]) return false;
+                idx++;
+              }
+              return true;
+            };
+
+            if (str_eq(var, "rho")) {
+              for (int iS = 0; iS < nS; ++iS) {
+                if (targetS == -1 || targetS == iS) {
+                  dRho[iS] += wave.amplitude * S;
+                }
+              }
+            } else if (str_eq(var, "ux")) {
+              for (int iS = 0; iS < nS; ++iS) {
+                if (targetS == -1 || targetS == iS) {
+                  dUx_w[iS] += wave.amplitude * S;
+                }
+              }
+            } else if (str_eq(var, "uy")) {
+              for (int iS = 0; iS < nS; ++iS) {
+                if (targetS == -1 || targetS == iS) {
+                  dUy_w[iS] += wave.amplitude * S;
+                }
+              }
+            } else if (str_eq(var, "uz")) {
+              for (int iS = 0; iS < nS; ++iS) {
+                if (targetS == -1 || targetS == iS) {
+                  dUz_w[iS] += wave.amplitude * S;
+                }
+              }
+            } else if (str_eq(var, "p")) {
+              for (int iS = 0; iS < nS; ++iS) {
+                if (targetS == -1 || targetS == iS) {
+                  dP[iS] += wave.amplitude * S;
+                }
+              }
+            } else if (str_eq(var, "ppar")) {
+              for (int iS = 0; iS < nS; ++iS) {
+                if (targetS == -1 || targetS == iS) {
+                  dPpar[iS] += wave.amplitude * S;
+                  hasPparPert = true;
+                }
+              }
+            } else if (str_eq(var, "bx")) {
+              dBx_w += wave.amplitude * S;
+            } else if (str_eq(var, "by")) {
+              dBy_w += wave.amplitude * S;
+            } else if (str_eq(var, "bz")) {
+              dBz_w += wave.amplitude * S;
+            } else if (str_eq(var, "ex")) {
+              dEx_w += wave.amplitude * S;
+            } else if (str_eq(var, "ey")) {
+              dEy_w += wave.amplitude * S;
+            } else if (str_eq(var, "ez")) {
+              dEz_w += wave.amplitude * S;
+            }
           }
 
           // Rotate perturbations to simulation/grid frame
-          Real dUx = dUx_w * ex_x + dUy_w * ey_x + dUz_w * ez_x;
-          Real dUy = dUx_w * ex_y + dUy_w * ey_y + dUz_w * ez_y;
-          Real dUz = dUx_w * ex_z + dUy_w * ey_z + dUz_w * ez_z;
+          Real dUx[3] = {0.0}, dUy[3] = {0.0}, dUz[3] = {0.0};
+          for (int iS = 0; iS < nS; ++iS) {
+            dUx[iS] = dUx_w[iS] * ex_x + dUy_w[iS] * ey_x + dUz_w[iS] * ez_x;
+            dUy[iS] = dUx_w[iS] * ex_y + dUy_w[iS] * ey_y + dUz_w[iS] * ez_y;
+            dUz[iS] = dUx_w[iS] * ex_z + dUy_w[iS] * ey_z + dUz_w[iS] * ez_z;
+          }
 
           Real dBx = dBx_w * ex_x + dBy_w * ey_x + dBz_w * ez_x;
           Real dBy = dBx_w * ex_y + dBy_w * ey_y + dBz_w * ez_y;
-          Real dBz = dBx_w * ex_z + dBy_w * ez_z + dBz_w * ez_z;
+          Real dBz = dBx_w * ex_z + dBy_w * ey_z + dBz_w * ez_z;
+
+          Real dEx = dEx_w * ex_x + dEy_w * ey_x + dEz_w * ez_x;
+          Real dEy = dEx_w * ex_y + dEy_w * ey_y + dEz_w * ez_y;
+          Real dEz = dEx_w * ex_z + dEy_w * ey_z + dEz_w * ez_z;
 
           // Apply background + perturbations to all fluids/species, scaled by
           // mass
           for (int iFluid = 0; iFluid < nFluid; ++iFluid) {
             const Real m = MoMi_S[iFluid];
-            Real rho = rho0 * m;
-            Real ux = ux0;
-            Real uy = uy0;
-            Real uz = uz0;
-            Real p = p0 * m;
-
-            if (waveType == "langmuir") {
-              if (iFluid == 0) { // Electrons
-                rho = (rho0 + waveAmp * cos(phase)) * m;
-              }
-              p = 0.0; // Cold plasma
-            } else {
-              rho = (rho0 + waveAmp * dRho) * m;
-              const Real dP_scaled = dP * (p0 / 0.6);
-              ux = ux0 + waveAmp * dUx;
-              uy = uy0 + waveAmp * dUy;
-              uz = uz0 + waveAmp * dUz;
-              p = (p0 + waveAmp * dP_scaled) * m;
-            }
+            Real rho = (rho0 + dRho[iFluid]) * m;
+            Real ux = ux0 + dUx[iFluid];
+            Real uy = uy0 + dUy[iFluid];
+            Real uz = uz0 + dUz[iFluid];
+            Real p = (p0 + dP[iFluid]) * m;
 
             arr(i, j, k, iRho_I[iFluid]) = rho;
             arr(i, j, k, iRhoUx_I[iFluid]) = rho * ux;
@@ -933,8 +1072,8 @@ void FluidInterface::set_node_fluid() {
             arr(i, j, k, iP_I[iFluid]) = p;
 
             if (iPpar_I[iFluid] >= 0) {
-              if (waveType == "anisotropic") {
-                arr(i, j, k, iPpar_I[iFluid]) = (p0 * (1.0 + waveAmp * S)) * m;
+              if (hasPparPert) {
+                arr(i, j, k, iPpar_I[iFluid]) = (p0 + dPpar[iFluid]) * m;
               } else {
                 arr(i, j, k, iPpar_I[iFluid]) = p;
               }
@@ -942,26 +1081,19 @@ void FluidInterface::set_node_fluid() {
           }
 
           // Apply background + perturbations to magnetic fields
-          arr(i, j, k, iBx) = bx0 + waveAmp * dBx;
-          arr(i, j, k, iBy) = by0 + waveAmp * dBy;
-          arr(i, j, k, iBz) = bz0 + waveAmp * dBz;
+          arr(i, j, k, iBx) = bx0 + dBx;
+          arr(i, j, k, iBy) = by0 + dBy;
+          arr(i, j, k, iBz) = bz0 + dBz;
 
           // Apply background + perturbations to electric fields if defined
           if (iEx >= 0 && iEy >= 0 && iEz >= 0) {
-            if (waveType == "langmuir") {
-              Real E_amp = -waveAmp * 4.0 * dPI / k_mag;
-              arr(i, j, k, iEx) = nx * E_amp * sin(phase);
-              arr(i, j, k, iEy) = ny * E_amp * sin(phase);
-              arr(i, j, k, iEz) = nz * E_amp * sin(phase);
-            } else {
-              const Real ux = ux0 + waveAmp * dUx;
-              const Real uy = uy0 + waveAmp * dUy;
-              const Real uz = uz0 + waveAmp * dUz;
+            const Real ux = ux0 + dUx[0];
+            const Real uy = uy0 + dUy[0];
+            const Real uz = uz0 + dUz[0];
 
-              arr(i, j, k, iEx) = -(uy * bz0 - uz * by0);
-              arr(i, j, k, iEy) = -(uz * bx0 - ux * bz0);
-              arr(i, j, k, iEz) = -(ux * by0 - uy * bx0);
-            }
+            arr(i, j, k, iEx) = -(uy * bz0 - uz * by0) + dEx;
+            arr(i, j, k, iEy) = -(uz * bx0 - ux * bz0) + dEy;
+            arr(i, j, k, iEz) = -(ux * by0 - uy * bx0) + dEz;
           }
         });
       }

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -428,8 +428,8 @@ void FluidInterface::read_param(const std::string& command, ReadParam& param) {
   if (command == "#NORMALIZATION") {
     param.read_var("lNorm", lNormSI);
     param.read_var("uNorm", uNormSI);
-  } else if (command == "#WAVE" || command == "#WAVE2" || command == "#WAVE4" || command == "#WAVE6" ||
-             command.rfind("#WAVE_FLEKS", 0) == 0) {
+  } else if (command == "#WAVE" || command == "#WAVE2" || command == "#WAVE4" ||
+             command == "#WAVE6" || command.rfind("#WAVE_FLEKS", 0) == 0) {
     WaveInfo info;
     param.read_var("NameVar", info.nameVar);
     param.read_var("Width", info.width);
@@ -798,10 +798,14 @@ void FluidInterface::set_node_fluid() {
   normalize_fluid_variables();
 
   if (!waveInfos.empty()) {
-    // Use the wavevector of the first wave command to define the main coordinate rotation.
-    Real kx = (waveInfos[0].lambdaX > 0.0) ? (2.0 * dPI / waveInfos[0].lambdaX) : 0.0;
-    Real ky = (waveInfos[0].lambdaY > 0.0) ? (2.0 * dPI / waveInfos[0].lambdaY) : 0.0;
-    Real kz = (waveInfos[0].lambdaZ > 0.0) ? (2.0 * dPI / waveInfos[0].lambdaZ) : 0.0;
+    // Use the wavevector of the first wave command to define the main
+    // coordinate rotation.
+    Real kx =
+        (waveInfos[0].lambdaX > 0.0) ? (2.0 * dPI / waveInfos[0].lambdaX) : 0.0;
+    Real ky =
+        (waveInfos[0].lambdaY > 0.0) ? (2.0 * dPI / waveInfos[0].lambdaY) : 0.0;
+    Real kz =
+        (waveInfos[0].lambdaZ > 0.0) ? (2.0 * dPI / waveInfos[0].lambdaZ) : 0.0;
     Real k_mag = sqrt(kx * kx + ky * ky + kz * kz);
 
     if (k_mag == 0.0) {
@@ -845,7 +849,7 @@ void FluidInterface::set_node_fluid() {
     bool isMHD = false;
 
     auto str_eq_det = [](const std::string& a, const char* b) {
-      char var[20] = {0};
+      char var[20] = { 0 };
       for (size_t c = 0; c < a.size() && c < 19; ++c) {
         char ch = a[c];
         if (ch >= 'A' && ch <= 'Z') {
@@ -855,26 +859,30 @@ void FluidInterface::set_node_fluid() {
         }
       }
       int len = 0;
-      while (var[len] != '\0') len++;
+      while (var[len] != '\0')
+        len++;
       if (len > 0 && var[len - 1] >= '0' && var[len - 1] <= '9') {
         var[len - 1] = '\0';
       }
       int idx = 0;
       while (var[idx] != '\0' || b[idx] != '\0') {
-        if (var[idx] != b[idx]) return false;
+        if (var[idx] != b[idx])
+          return false;
         idx++;
       }
       return true;
     };
 
     for (const auto& wave : waveInfos) {
-      if (str_eq_det(wave.nameVar, "ppar")) isAnisotropic = true;
+      if (str_eq_det(wave.nameVar, "ppar"))
+        isAnisotropic = true;
       if (str_eq_det(wave.nameVar, "ex") || str_eq_det(wave.nameVar, "rho")) {
         if (str_eq_det(wave.nameVar, "ex") || wave.nameVar == "rho0") {
           isLangmuir = true;
         }
       }
-      if (str_eq_det(wave.nameVar, "by") || str_eq_det(wave.nameVar, "bz")) isMHD = true;
+      if (str_eq_det(wave.nameVar, "by") || str_eq_det(wave.nameVar, "bz"))
+        isMHD = true;
     }
 
     if (isAnisotropic) {
@@ -915,10 +923,10 @@ void FluidInterface::set_node_fluid() {
           const Real z = k * dx[iz_] + plo[iz_];
 
           // Initialize wave-frame perturbations for nS species
-          Real dRho[3] = {0.0};
-          Real dUx_w[3] = {0.0}, dUy_w[3] = {0.0}, dUz_w[3] = {0.0};
-          Real dP[3] = {0.0};
-          Real dPpar[3] = {0.0};
+          Real dRho[3] = { 0.0 };
+          Real dUx_w[3] = { 0.0 }, dUy_w[3] = { 0.0 }, dUz_w[3] = { 0.0 };
+          Real dP[3] = { 0.0 };
+          Real dPpar[3] = { 0.0 };
           bool hasPparPert = false;
 
           Real dBx_w = 0.0, dBy_w = 0.0, dBz_w = 0.0;
@@ -956,7 +964,7 @@ void FluidInterface::set_node_fluid() {
             Real S = pow(term, wave.exponent);
 
             // Match variable name (case insensitive manually or via check)
-            char var[20] = {0};
+            char var[20] = { 0 };
             for (size_t c = 0; c < wave.nameVar.size() && c < 19; ++c) {
               char ch = wave.nameVar[c];
               if (ch >= 'A' && ch <= 'Z') {
@@ -981,7 +989,8 @@ void FluidInterface::set_node_fluid() {
             auto str_eq = [](const char* a, const char* b) {
               int idx = 0;
               while (a[idx] != '\0' || b[idx] != '\0') {
-                if (a[idx] != b[idx]) return false;
+                if (a[idx] != b[idx])
+                  return false;
                 idx++;
               }
               return true;
@@ -1040,7 +1049,7 @@ void FluidInterface::set_node_fluid() {
           }
 
           // Rotate perturbations to simulation/grid frame
-          Real dUx[3] = {0.0}, dUy[3] = {0.0}, dUz[3] = {0.0};
+          Real dUx[3] = { 0.0 }, dUy[3] = { 0.0 }, dUz[3] = { 0.0 };
           for (int iS = 0; iS < nS; ++iS) {
             dUx[iS] = dUx_w[iS] * ex_x + dUy_w[iS] * ey_x + dUz_w[iS] * ez_x;
             dUy[iS] = dUx_w[iS] * ex_y + dUy_w[iS] * ey_y + dUz_w[iS] * ez_y;

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -410,6 +410,11 @@ void FluidInterface::read_param(const std::string& command, ReadParam& param) {
   if (command == "#NORMALIZATION") {
     param.read_var("lNorm", lNormSI);
     param.read_var("uNorm", uNormSI);
+  } else if (command == "#WAVE") {
+    param.read_var("waveType", waveType);
+    param.read_var("waveAmp", waveAmp);
+    param.read_var("waveLength", waveLength);
+    param.read_var("waveAngle", waveAngle);
   } else if (command == "#SCALINGFACTOR") {
     param.read_var("scaling", ScalingFactor);
   } else if (command == "#BODYSIZE") {
@@ -756,6 +761,101 @@ void FluidInterface::set_node_fluid() {
 
   calc_current();
   normalize_fluid_variables();
+
+  if (waveType != "none") {
+    // Check if cold plasma is requested via PARAM.in (T = 0)
+    bool isColdPlasma = false;
+    if (uniformState.size() > 4) {
+      isColdPlasma = (uniformState[4] == 0.0);
+    }
+
+    Real rho0 = 1.0;
+    Real p0 = isColdPlasma ? 0.0 : 0.6;
+    Real ux0 = 0.0, uy0 = 0.0, uz0 = 0.0;
+    Real bx0 = 0.0, by0 = 0.0, bz0 = 0.0;
+
+    if (waveType != "sound") {
+      bx0 = 1.0;
+      by0 = sqrt(2.0);
+      bz0 = 0.5;
+    }
+
+    for (int iLev = 0; iLev < n_lev(); iLev++) {
+      const auto& dx = Geom(iLev).CellSize();
+      const auto plo = Geom(iLev).ProbLo();
+
+      for (MFIter mfi(nodeFluid[iLev]); mfi.isValid(); ++mfi) {
+        const Box& box = mfi.fabbox();
+        const Array4<Real>& arr = nodeFluid[iLev][mfi].array();
+
+        ParallelFor(box, [=](int i, int j, int k) noexcept {
+          const Real x = i * dx[ix_] + plo[ix_];
+          const Real k_wave = 2.0 * dPI / waveLength;
+          const Real phase = k_wave * x;
+          const Real S = sin(phase);
+
+          // 2. Set wave eigenfunctions/perturbations
+          Real dRho = 0.0, dUx = 0.0, dUy = 0.0, dUz = 0.0, dP = 0.0;
+          Real dBx = 0.0, dBy = 0.0, dBz = 0.0;
+
+          if (waveType == "sound") {
+            dRho = 1.0 * S;
+            dUx  = -1.0 * S;
+            dP   = 1.0 * S;
+          } else if (waveType == "fast") {
+            dRho = 0.4472135954999580 * S;
+            dUx  = -0.8944271909999160 * S;
+            dUy  = 0.4216370213557840 * S;
+            dUz  = 0.1490711984999860 * S;
+            dP   = 0.4472135954999580 * S;
+            dBy  = 0.8432740427115680 * S;
+            dBz  = 0.2981423969999720 * S;
+          } else if (waveType == "alfven") {
+            dUy  = -0.3333333333333333 * S;
+            dUz  = 0.9428090415820634 * S;
+            dBy  = -0.3333333333333333 * S;
+            dBz  = 0.9428090415820634 * S;
+          } else if (waveType == "slow") {
+            dRho = 0.8944271909999159 * S;
+            dUx  = -0.4472135954999579 * S;
+            dUy  = -0.8432740427115680 * S;
+            dUz  = -0.2981423969999720 * S;
+            dP   = 0.8944271909999159 * S;
+            dBy  = -0.4216370213557841 * S;
+            dBz  = -0.1490711984999860 * S;
+          }
+
+          // Apply background + perturbations to all fluids/species, scaled by mass
+          for (int iFluid = 0; iFluid < nFluid; ++iFluid) {
+            const Real m = MoMi_S[iFluid];
+            const Real rho = (rho0 + waveAmp * dRho) * m;
+            
+            // Physically scale pressure perturbation by background pressure ratio
+            const Real dP_scaled = dP * (p0 / 0.6);
+            
+            arr(i, j, k, iRho_I[iFluid]) = rho;
+            arr(i, j, k, iRhoUx_I[iFluid]) = rho * (ux0 + waveAmp * dUx);
+            arr(i, j, k, iRhoUy_I[iFluid]) = rho * (uy0 + waveAmp * dUy);
+            arr(i, j, k, iRhoUz_I[iFluid]) = rho * (uz0 + waveAmp * dUz);
+            arr(i, j, k, iP_I[iFluid]) = (p0 + waveAmp * dP_scaled) * m;
+          }
+
+          // Apply background + perturbations to magnetic fields
+          arr(i, j, k, iBx) = bx0 + waveAmp * dBx;
+          arr(i, j, k, iBy) = by0 + waveAmp * dBy;
+          arr(i, j, k, iBz) = bz0 + waveAmp * dBz;
+        });
+      }
+
+      nodeFluid[iLev].FillBoundary(Geom(iLev).periodicity());
+      
+      // Recalculate cell-centered centerB from nodeFluid
+      average_node_to_cellcenter(centerB[iLev], 0, nodeFluid[iLev], iBx,
+                                 centerB[iLev].nComp(), centerB[iLev].nGrow());
+      centerB[iLev].FillBoundary(Geom(iLev).periodicity());
+    }
+  }
+
   convert_moment_to_velocity();
 
   // save_amrex_file();

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -800,39 +800,41 @@ void FluidInterface::set_node_fluid() {
 
           if (waveType == "sound") {
             dRho = 1.0 * S;
-            dUx  = -1.0 * S;
-            dP   = 1.0 * S;
+            dUx = -1.0 * S;
+            dP = 1.0 * S;
           } else if (waveType == "fast") {
             dRho = 0.4472135954999580 * S;
-            dUx  = -0.8944271909999160 * S;
-            dUy  = 0.4216370213557840 * S;
-            dUz  = 0.1490711984999860 * S;
-            dP   = 0.4472135954999580 * S;
-            dBy  = 0.8432740427115680 * S;
-            dBz  = 0.2981423969999720 * S;
+            dUx = -0.8944271909999160 * S;
+            dUy = 0.4216370213557840 * S;
+            dUz = 0.1490711984999860 * S;
+            dP = 0.4472135954999580 * S;
+            dBy = 0.8432740427115680 * S;
+            dBz = 0.2981423969999720 * S;
           } else if (waveType == "alfven") {
-            dUy  = -0.3333333333333333 * S;
-            dUz  = 0.9428090415820634 * S;
-            dBy  = -0.3333333333333333 * S;
-            dBz  = 0.9428090415820634 * S;
+            dUy = -0.3333333333333333 * S;
+            dUz = 0.9428090415820634 * S;
+            dBy = -0.3333333333333333 * S;
+            dBz = 0.9428090415820634 * S;
           } else if (waveType == "slow") {
             dRho = 0.8944271909999159 * S;
-            dUx  = -0.4472135954999579 * S;
-            dUy  = -0.8432740427115680 * S;
-            dUz  = -0.2981423969999720 * S;
-            dP   = 0.8944271909999159 * S;
-            dBy  = -0.4216370213557841 * S;
-            dBz  = -0.1490711984999860 * S;
+            dUx = -0.4472135954999579 * S;
+            dUy = -0.8432740427115680 * S;
+            dUz = -0.2981423969999720 * S;
+            dP = 0.8944271909999159 * S;
+            dBy = -0.4216370213557841 * S;
+            dBz = -0.1490711984999860 * S;
           }
 
-          // Apply background + perturbations to all fluids/species, scaled by mass
+          // Apply background + perturbations to all fluids/species, scaled by
+          // mass
           for (int iFluid = 0; iFluid < nFluid; ++iFluid) {
             const Real m = MoMi_S[iFluid];
             const Real rho = (rho0 + waveAmp * dRho) * m;
-            
-            // Physically scale pressure perturbation by background pressure ratio
+
+            // Physically scale pressure perturbation by background pressure
+            // ratio
             const Real dP_scaled = dP * (p0 / 0.6);
-            
+
             arr(i, j, k, iRho_I[iFluid]) = rho;
             arr(i, j, k, iRhoUx_I[iFluid]) = rho * (ux0 + waveAmp * dUx);
             arr(i, j, k, iRhoUy_I[iFluid]) = rho * (uy0 + waveAmp * dUy);
@@ -859,7 +861,7 @@ void FluidInterface::set_node_fluid() {
       }
 
       nodeFluid[iLev].FillBoundary(Geom(iLev).periodicity());
-      
+
       // Recalculate cell-centered centerB from nodeFluid
       average_node_to_cellcenter(centerB[iLev], 0, nodeFluid[iLev], iBx,
                                  centerB[iLev].nComp(), centerB[iLev].nGrow());

--- a/src/PicIO.cpp
+++ b/src/PicIO.cpp
@@ -630,7 +630,7 @@ void Pic::write_diag_log(bool doForce, bool doCreateFile) {
       }
     }
     if (doDiagField) {
-      of << "\tmaxBy\tmaxBz";
+      of << "\tmaxBy\tmaxBz\tmaxEy";
     }
     of << "\n";
     of.close();
@@ -696,11 +696,12 @@ void Pic::write_diag_log(bool doForce, bool doCreateFile) {
 
   // Collect field statistics (IO-only, no MPI needed beyond the data already
   // on the IO processor for nodeB).
-  double max_By = 0.0, max_Bz = 0.0;
+  double max_By = 0.0, max_Bz = 0.0, max_Ey = 0.0;
   if (doDiagField) {
     for (int iLev = 0; iLev < n_lev(); iLev++) {
       max_By = std::max(max_By, nodeB[iLev].norm0(1));
       max_Bz = std::max(max_Bz, nodeB[iLev].norm0(2));
+      max_Ey = std::max(max_Ey, nodeE[iLev].norm0(1));
     }
   }
 
@@ -725,7 +726,7 @@ void Pic::write_diag_log(bool doForce, bool doCreateFile) {
     }
 
     if (doDiagField) {
-      of << "\t" << max_By << "\t" << max_Bz;
+      of << "\t" << max_By << "\t" << max_Bz << "\t" << max_Ey;
     }
 
     of << "\n";

--- a/src/PlotWriter.cpp
+++ b/src/PlotWriter.cpp
@@ -159,20 +159,29 @@ void PlotWriter::init() {
   // Find out output format.
   if (plotString.find("ascii") != std::string::npos) {
     outputFormat = "ascii";
+    doSaveBinary = false;
   } else if (plotString.find("real4") != std::string::npos) {
     outputFormat = "real4";
+    doSaveBinary = true;
   } else if (plotString.find("real8") != std::string::npos) {
     outputFormat = "real8";
+    doSaveBinary = true;
   } else if (plotString.find("amrex") != std::string::npos) {
     outputFormat = "amrex";
+    doSaveBinary = true;
   } else if (plotString.find("hdf5") != std::string::npos) {
     outputFormat = "hdf5";
+    doSaveBinary = true;
   } else {
     if (isVerbose)
       std::cout << errorPrefix
                 << "Unknown plot output format!! plotString = " << plotString
                 << std::endl;
     abort();
+  }
+
+  if (outputFormat == "ascii") {
+    useMpiIO = false;
   }
 
   // Find out output unit.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,14 +1,57 @@
-# FLEKS Unit Tests
+# FLEKS Testing Framework
 
-This directory is the future home for standalone unit testing of the FLEKS codebase (independent of the overarching SWMF macro regression tests).
+This directory contains standalone validation and physics tests for **FLEKS (Flexible Exascale Kinetic Simulator)**. These tests verify the core Particle-in-Cell (PIC) solver's mathematical models, physical transport, boundary conditions, and collision/ionization processes completely independent of SWMF coupling.
 
-## Framework Guidance
-The recommended framework for internal kinetic math and grid testing is **GoogleTest (gtest)** or **Catch2**. 
+---
 
-When adding tests here in the future:
-1. Initialize the framework of your choice (e.g., via a standalone CMake build system targeting this folder).
-2. Tests should execute entirely isolated from SWMF Fortran wrappers (focus purely on `src/` classes like `Particles.cpp`, `LinearSolver.cpp`, and mathematical `GridUtility` routines).
-3. If leveraging AMReX data arrays, ensure your test runner initializes AMReX via `amrex::Initialize()` before the test suite and calls `amrex::Finalize()` during test tear-down.
+## 🚀 Running the Tests
 
-## Macro Regression Tests
-If you simply want to test whether FLEKS correctly couples with BATS-R-US or global SWMF targets, please navigate to the root SWMF directory and run `make test16_3d` or other pre-compiled XML routines in the SWMF test catalog.
+A unified Python runner is provided to dynamically discover, execute, and validate the test suite:
+
+```bash
+python3 tests/test_standalone/validate_tests.py
+```
+
+### What the test runner does:
+1. Scans the `tests/test_standalone/` directory for any subdirectories containing a `PARAM.in` configuration file.
+2. Initializes the execution directory `run_test/` with necessary symlinks to the FLEKS executable and post-processing tools.
+3. Copies the respective `PARAM.in` file, runs `./FLEKS.exe`, and invokes the post-processing pipeline `./PostProc.pl`.
+4. Parses diagnostic outputs and validates physical correctness against analytical models or exit-code verifications.
+
+---
+
+## 🛠️ Prerequisites & Compilation
+
+Before running the tests, both the main **FLEKS executable** and the **IDL post-processor (`PostIDL.exe`)** must be compiled.
+
+### 1. Compile the FLEKS Executable
+Ensure the standalone FLEKS executable is compiled first:
+```bash
+make EXE
+```
+
+### 2. Compile the Post-Processor (`PIDL`)
+The test runner executes post-processing scripts which require the `PostIDL.exe` executable. If you encounter the following error:
+> `ERROR in pIDL: .../PC/PostIDL.exe is not available, please make PIDL`
+
+You can build the post-processor from the FLEKS root directory by running:
+```bash
+make -C share/Library/src PIDL
+```
+*(This compiles `PostIDL.exe` and places the binary under the `bin/` directory, resolving the symlink dependency).*
+
+---
+
+## 📂 Test Catalog
+
+The test suite in `tests/test_standalone/` covers a wide range of physical and numerical configurations:
+
+*   **`box/`**: 0D equilibrium test validating spatial particle injection, population growth, and uniform loading.
+*   **`chamber/`**: 1D inflow and free outflow boundary test verifying convergence to steady-state particle count.
+*   **`photoionization/`**: Validates pair-injection of ions and electrons to ensure local and global charge conservation.
+*   **`electron_impact/`**: Verifies collision probabilities and Lotz cross-sections using a Monte Carlo Collision (MCC) algorithm.
+*   **`charge_exchange/`**: Validates ion drift deceleration and thermal cooling via MCC velocity replacements.
+*   **`exosphere/`**: Combined test verifying exospheric photoionization, electron impact, and charge exchange running concurrently.
+*   **`beam/`**: 1D ion beam electromagnetic instability test validating cyclotron wave growth and energy conservation.
+*   **`tophat/`**: 1D electromagnetic wave propagation test validating $B_z$ and $E_y$ field dynamics under the EM solver with zero particles.
+*   **Wave & Plasma Modes**: Includes tests for `alfven_wave`, `fast_wave`, `slow_wave`, `sound_wave`, and `langmuir` oscillations to verify plasma physics modes.

--- a/tests/test_standalone/README.md
+++ b/tests/test_standalone/README.md
@@ -15,6 +15,7 @@ Each test case is contained within its own dedicated subdirectory containing a `
 *   **[charge_exchange/](file:///home/hyzhou/simulation/SWMF/PC/FLEKS_myversion/tests/test_standalone/charge_exchange/)**: Exospheric charge exchange test validating ion drift deceleration and thermal cooling through in-place velocity replacements using a Monte Carlo Collision (MCC) algorithm.
 *   **[exosphere/](file:///home/hyzhou/simulation/SWMF/PC/FLEKS_myversion/tests/test_standalone/exosphere/)**: Combined exosphere processes test validating exospheric photoionization pair-injection, electron impact ionization MCC, and exospheric charge exchange MCC running concurrently.
 *   **[beam/](file:///home/hyzhou/simulation/SWMF/PC/FLEKS_myversion/tests/test_standalone/beam/)**: 1D ion beam electromagnetic instability test validating cyclotron wave growth, transverse magnetic field amplification, and energy conservation.
+*   **[tophat/](file:///home/hyzhou/simulation/SWMF/PC/FLEKS_myversion/tests/test_standalone/tophat/)**: 1D electromagnetic top-hat wave propagation test validating $B_z$ and $E_y$ field dynamics under the EM solver with zero particles.
 
 
 ## Running the Tests

--- a/tests/test_standalone/alfven_wave/PARAM.in
+++ b/tests/test_standalone/alfven_wave/PARAM.in
@@ -1,0 +1,89 @@
+#DESCRIPTION
+1D Adiabatic MHD Alfven Wave Standalone Test
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+0.0                    xMin
+1.0                    xMax
+0.0                    yMin
+1.0                    yMax
+0.0                    zMin
+1.0                    zMax
+
+#NCELL
+64                      nCellX
+1                       nCellY
+1                       nCellZ
+
+#MAXBLOCKSIZE
+64                      maxBlockSizeX
+1                       maxBlockSizeY
+1                       maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#ELECTRON
+-100                    electronChargePerMass
+
+#PLASMA
+2                       nSpecies
+0.01                    mass
+-1.0                    charge
+1.0                     mass
+1.0                     charge
+
+#UNIFORMSTATE
+0.01                    rho [amu/cc] (Species 0)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+1000.0                  T [K]
+1.0                     rho [amu/cc] (Species 1)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+1000.0                  T [K]
+1.0                     bx [T]
+1.4142135623730951      by [T]
+0.5                     bz [T]
+0.0                     ex [V/m]
+0.0                     ey [V/m]
+0.0                     ez [V/m]
+
+#WAVE
+alfven                  waveType
+1.0                       waveAmp
+1.0                     waveLength
+0.0                     waveAngle
+
+#TIMESTEPPING
+T                       useFixedDt
+0.01                    dt
+
+#NORMALIZATION
+1.0                     lNormSI
+1.0                     uNormSI
+
+#MONITOR
+1                       dnReport
+
+#PARTICLES
+100                     nParticle per cell in X
+1                       nParticle per cell in Y
+1                       nParticle per cell in Z
+
+#DIAGNOSTIC
+T                       doParticleDiag
+T                       doFieldDiag
+
+#STOP
+-1                      MaxIter
+1.0                     TimeMax

--- a/tests/test_standalone/alfven_wave/PARAM.in
+++ b/tests/test_standalone/alfven_wave/PARAM.in
@@ -59,11 +59,41 @@ T                       solveEM
 0.0                     ez [V/m]
 
 #WAVE
-alfven                  waveType
-1.0                       waveAmp
+uy                      NameVar
+0.0                     Width
+-0.3333333333333333     Amplitude
 1.0                     LambdaX
 -1.0                    LambdaY
 -1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+uz                      NameVar
+0.0                     Width
+0.9428090415820634      Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+by                      NameVar
+0.0                     Width
+-0.3333333333333333     Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+bz                      NameVar
+0.0                     Width
+0.9428090415820634      Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/alfven_wave/PARAM.in
+++ b/tests/test_standalone/alfven_wave/PARAM.in
@@ -61,8 +61,9 @@ T                       solveEM
 #WAVE
 alfven                  waveType
 1.0                       waveAmp
-1.0                     waveLength
-0.0                     waveAngle
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/alfven_wave/README.md
+++ b/tests/test_standalone/alfven_wave/README.md
@@ -15,7 +15,7 @@ This is a standalone test designed to verify the propagation of a 1D linear adia
   - $\delta B_y = -0.3333333\,\text{amp} \sin(kx)$
   - $\delta B_z = 0.9428090\,\text{amp} \sin(kx)$
   - $\delta \rho = 0.0$, $\delta u_x = 0.0$, $\delta p = 0.0$.
-- **Solver Setup**: Treated in hybrid PIC mode with kinetic ion particles ($nSpecies = 1$) and background electron fluid. Field solver is enabled (`solveEM = T`).
+- **Solver Setup**: Treated in full PIC mode with kinetic electrons (Species 0) and kinetic ions (Species 1). Field solver is enabled (`solveEM = T`).
 - **Wave Propagation**: The Alfvén speed is $v_A = B_{0x} / \sqrt{\rho_0} = 1.0$. For wavelength $\lambda = 1.0$, the wave period is exactly $T_{\text{max}} = 1.0$.
 
 ## Expected Results

--- a/tests/test_standalone/alfven_wave/README.md
+++ b/tests/test_standalone/alfven_wave/README.md
@@ -1,0 +1,23 @@
+# 1D Adiabatic MHD Alfvén Wave Test
+
+## Description
+This is a standalone test designed to verify the propagation of a 1D linear adiabatic MHD Alfvén wave in FLEKS. The test initializes shear transverse velocity and magnetic field perturbations in both the kinetic ion particles and electromagnetic fields on a periodic grid, simulating wave propagation over exactly one wave period.
+
+## Physics & Solver Setup
+- **Geometry & Boundaries**: 1D periodic grid (64 cells in $X$, 1 in $Y$ and $Z$).
+- **Background State (Normalized)**: 
+  - Ion density $\rho_0 = 1.0$, pressure $p_0 = 0.6$ ($\gamma = 5/3$), bulk velocity $\vec{u}_0 = (0.0, 0.0, 0.0)$.
+  - Guiding magnetic field $\vec{B}_0 = (1.0, \sqrt{2.0}, 0.5)$.
+- **Perturbations (Eigenfunctions)**:
+  - Perturbation amplitude $\text{amp} = 10^{-4}$, wavelength $\lambda = 1.0$.
+  - $\delta u_y = -0.3333333\,\text{amp} \sin(kx)$
+  - $\delta u_z = 0.9428090\,\text{amp} \sin(kx)$
+  - $\delta B_y = -0.3333333\,\text{amp} \sin(kx)$
+  - $\delta B_z = 0.9428090\,\text{amp} \sin(kx)$
+  - $\delta \rho = 0.0$, $\delta u_x = 0.0$, $\delta p = 0.0$.
+- **Solver Setup**: Treated in hybrid PIC mode with kinetic ion particles ($nSpecies = 1$) and background electron fluid. Field solver is enabled (`solveEM = T`).
+- **Wave Propagation**: The Alfvén speed is $v_A = B_{0x} / \sqrt{\rho_0} = 1.0$. For wavelength $\lambda = 1.0$, the wave period is exactly $T_{\text{max}} = 1.0$.
+
+## Expected Results
+- **Particle Count Conservation**: The total number of particles must remain exactly constant (deviation $< 10^{-5}$).
+- **Kinetic Energy Stability**: The total kinetic energy must remain stable over the entire wave period (variation $< 10\%$), as the linear wave propagates without excessive numerical dissipation or grid heating.

--- a/tests/test_standalone/anisotropic_wave/PARAM.in
+++ b/tests/test_standalone/anisotropic_wave/PARAM.in
@@ -61,8 +61,9 @@ T                       solveEM
 #WAVE
 anisotropic             waveType
 0.1                     waveAmp
-32.0                    waveLength
-0.0                     waveAngle
+32.0                    LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/anisotropic_wave/PARAM.in
+++ b/tests/test_standalone/anisotropic_wave/PARAM.in
@@ -59,11 +59,50 @@ T                       solveEM
 0.0                     ez [V/m]
 
 #WAVE
-anisotropic             waveType
-0.1                     waveAmp
+rho                     NameVar
+0.0                     Width
+0.1                     Amplitude
 32.0                    LambdaX
 -1.0                    LambdaY
 -1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+ux                      NameVar
+0.0                     Width
+0.005                   Amplitude
+32.0                    LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+p                       NameVar
+0.0                     Width
+7.5e-5                  Amplitude
+32.0                    LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+ppar                    NameVar
+0.0                     Width
+4.5e-5                  Amplitude
+32.0                    LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+by                      NameVar
+0.0                     Width
+0.004                   Amplitude
+32.0                    LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/anisotropic_wave/PARAM.in
+++ b/tests/test_standalone/anisotropic_wave/PARAM.in
@@ -1,0 +1,96 @@
+#DESCRIPTION
+1D Anisotropic MHD Wave Standalone Test
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+0.0                    xMin
+32.0                   xMax
+0.0                    yMin
+1.0                    yMax
+0.0                    zMin
+1.0                    zMax
+
+#NCELL
+64                      nCellX
+1                       nCellY
+1                       nCellZ
+
+#MAXBLOCKSIZE
+64                      maxBlockSizeX
+1                       maxBlockSizeY
+1                       maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#ELECTRON
+-25                     electronChargePerMass
+
+#PLASMA
+2                       nSpecies
+0.04                    mass
+-1.0                    charge
+1.0                     mass
+1.0                     charge
+
+#UNIFORMSTATE
+0.02606                 rho [amu/cc] (Species 0)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+545.0                  T [K]
+0.6516                  rho [amu/cc] (Species 1)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+545.0                  T [K]
+0.0                     bx [T]
+4.1758e-11              by [T]
+0.0                     bz [T]
+0.0                     ex [V/m]
+0.0                     ey [V/m]
+0.0                     ez [V/m]
+
+#WAVE
+anisotropic             waveType
+0.1                     waveAmp
+32.0                    waveLength
+0.0                     waveAngle
+
+#TIMESTEPPING
+T                       useFixedDt
+12.8                    dt
+
+#NORMALIZATION
+1e6                     lNormSI
+1e5                     uNormSI
+
+#MONITOR
+10                      dnReport
+
+#PARTICLES
+100                     nParticle per cell in X
+1                       nParticle per cell in Y
+1                       nParticle per cell in Z
+
+#DIAGNOSTIC
+T                       doParticleDiag
+T                       doFieldDiag
+
+#SAVEPLOT
+1                                 nPlot
+z=0 fluid ascii pic               plotString
+-1                                dn
+640.0                             dt
+1                                 dx
+
+#STOP
+-1                      MaxIter
+6400.0                  TimeMax

--- a/tests/test_standalone/anisotropic_wave/README.md
+++ b/tests/test_standalone/anisotropic_wave/README.md
@@ -1,0 +1,24 @@
+# 1D Anisotropic MHD Wave Test
+
+## Description
+This is a standalone test designed to verify the propagation of a 1D linear anisotropic MHD wave perpendicular to the magnetic field (the fast wave in anisotropic MHD, also known as the CGL/anisotropic fast magnetosonic wave) as described in Daldorff et al. (2014) and Key Notes in Plasma Physics.
+
+## Physics & Solver Setup
+- **Geometry & Boundaries**: 1D periodic grid ($64$ cells in $X$, $1$ in $Y$ and $Z$, with domain length $L_x = 32.0$).
+- **Background State (Normalized)**: 
+  - Ion density $\rho_0 = 1.0$, pressure $p_0 = 4.5 \times 10^{-4}$ ($\gamma = 5/3$), bulk velocity $\vec{u}_0 = (0.0, 0.0, 0.0)$.
+  - Guiding magnetic field $\vec{B}_0 = (0.0, 0.04, 0.0)$.
+- **Perturbations (Eigenfunctions)**:
+  - Perturbation amplitude $\delta = 0.1$ (moderately non-linear to be clearly visible above the PIC noise), wavelength $\lambda = 32.0$.
+  - $\rho = \rho_0 [1 + \delta \sin(kx)]$
+  - $u_x = V_f \delta \sin(kx)$
+  - $p = p_0 [1 + \gamma \delta \sin(kx)]$
+  - $p_\parallel = p_0 [1 + \delta \sin(kx)]$
+  - $B_y = B_0 [1 + \delta \sin(kx)]$
+  - Where the CGL perpendicular fast magnetosonic speed is:
+    $$V_f = \sqrt{\frac{B_0^2 + 2 p_0}{\rho_0}} = 0.05$$
+- **Solver Setup**: Full PIC mode with kinetic electrons (Species 0) and kinetic ions (Species 1). Field solver is enabled (`solveEM = T`).
+
+## Expected Results
+- **Particle Count Conservation**: The total number of particles must remain exactly constant (deviation $< 10^{-5}$).
+- **Kinetic Energy Stability**: The total kinetic energy must remain stable (variation $< 20\%$), as the linear wave propagates without excessive numerical dissipation or grid heating.

--- a/tests/test_standalone/beam/PARAM.in
+++ b/tests/test_standalone/beam/PARAM.in
@@ -34,12 +34,19 @@ T                       solveEM
 -100                    electronChargePerMass
 
 #PLASMA
-1                       nSpecies
+2                       nSpecies
+0.01                    mass
+-1.0                    charge
 1.0                     mass
 1.0                     charge
 
 #UNIFORMSTATE
-5.0                     rho [amu/cc]
+0.05                    rho [amu/cc] (Species 0 electrons; n_e = n_i = 5/cc, rho_e = n_e*m_e = 0.05)
+-400.0                  ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+10000.0                 T [K]
+5.0                     rho [amu/cc] (Species 1 ions; n_i = 5/cc)
 -400.0                  ux [km/s]
 0.0                     uy [km/s]
 0.0                     uz [km/s]
@@ -53,7 +60,7 @@ T                       solveEM
 
 #TESTCASE
 Beam
-0                       iSpecies
+1                       iSpecies
 0.01                    ratio
 0.4                     vel
 0.0                     vel

--- a/tests/test_standalone/fast_wave/PARAM.in
+++ b/tests/test_standalone/fast_wave/PARAM.in
@@ -59,11 +59,68 @@ T                       solveEM
 0.0                     ez [V/m]
 
 #WAVE
-fast                    waveType
-1.0                      waveAmp
+rho                     NameVar
+0.0                     Width
+0.4472135954999580      Amplitude
 1.0                     LambdaX
 -1.0                    LambdaY
 -1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+ux                      NameVar
+0.0                     Width
+-0.8944271909999160     Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+uy                      NameVar
+0.0                     Width
+0.4216370213557840      Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+uz                      NameVar
+0.0                     Width
+0.1490711984999860      Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+p                       NameVar
+0.0                     Width
+0.4472135954999580      Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+by                      NameVar
+0.0                     Width
+0.8432740427115680      Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+bz                      NameVar
+0.0                     Width
+0.2981423969999720      Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/fast_wave/PARAM.in
+++ b/tests/test_standalone/fast_wave/PARAM.in
@@ -1,0 +1,96 @@
+#DESCRIPTION
+1D Adiabatic MHD Fast Wave Standalone Test
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+0.0                    xMin
+1.0                    xMax
+0.0                    yMin
+1.0                    yMax
+0.0                    zMin
+1.0                    zMax
+
+#NCELL
+64                      nCellX
+1                       nCellY
+1                       nCellZ
+
+#MAXBLOCKSIZE
+64                      maxBlockSizeX
+1                       maxBlockSizeY
+1                       maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#ELECTRON
+-100                    electronChargePerMass
+
+#PLASMA
+2                       nSpecies
+0.01                    mass
+-1.0                    charge
+1.0                     mass
+1.0                     charge
+
+#UNIFORMSTATE
+0.01                    rho [amu/cc] (Species 0)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+1000.0                  T [K]
+1.0                     rho [amu/cc] (Species 1)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+1000.0                  T [K]
+1.0                     bx [T]
+1.4142135623730951      by [T]
+0.5                     bz [T]
+0.0                     ex [V/m]
+0.0                     ey [V/m]
+0.0                     ez [V/m]
+
+#WAVE
+fast                    waveType
+1.0                      waveAmp
+1.0                     waveLength
+0.0                     waveAngle
+
+#TIMESTEPPING
+T                       useFixedDt
+0.01                    dt
+
+#NORMALIZATION
+1.0                     lNormSI
+1.0                     uNormSI
+
+#MONITOR
+1                       dnReport
+
+#PARTICLES
+100                     nParticle per cell in X
+1                       nParticle per cell in Y
+1                       nParticle per cell in Z
+
+#DIAGNOSTIC
+T                       doParticleDiag
+T                       doFieldDiag
+
+#SAVEPLOT
+1                                 nPlot
+z=0 fluid ascii pic               plotString
+-1                                dn
+0.1                               dt
+1                                 dx
+
+#STOP
+-1                      MaxIter
+0.5                     TimeMax

--- a/tests/test_standalone/fast_wave/PARAM.in
+++ b/tests/test_standalone/fast_wave/PARAM.in
@@ -61,8 +61,9 @@ T                       solveEM
 #WAVE
 fast                    waveType
 1.0                      waveAmp
-1.0                     waveLength
-0.0                     waveAngle
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/fast_wave/README.md
+++ b/tests/test_standalone/fast_wave/README.md
@@ -1,0 +1,25 @@
+# 1D Adiabatic MHD Fast Wave Test
+
+## Description
+This is a standalone test designed to verify the propagation of a 1D linear adiabatic MHD fast magnetosonic wave in FLEKS. The test initializes self-consistent perturbations in both the kinetic ion particles and electromagnetic fields on a periodic grid, simulating wave propagation over exactly one wave period.
+
+## Physics & Solver Setup
+- **Geometry & Boundaries**: 1D periodic grid (64 cells in $X$, 1 in $Y$ and $Z$).
+- **Background State (Normalized)**: 
+  - Ion density $\rho_0 = 1.0$, pressure $p_0 = 0.6$ ($\gamma = 5/3$), bulk velocity $\vec{u}_0 = (0.0, 0.0, 0.0)$.
+  - Guiding magnetic field $\vec{B}_0 = (1.0, \sqrt{2.0}, 0.5)$.
+- **Perturbations (Eigenfunctions)**:
+  - Perturbation amplitude $\text{amp} = 10^{-4}$, wavelength $\lambda = 1.0$.
+  - $\delta \rho = 0.4472136\,\text{amp} \sin(kx)$
+  - $\delta u_x = -0.8944272\,\text{amp} \sin(kx)$
+  - $\delta u_y = 0.4216370\,\text{amp} \sin(kx)$
+  - $\delta u_z = 0.1490712\,\text{amp} \sin(kx)$
+  - $\delta p = 0.4472136\,\text{amp} \sin(kx)$
+  - $\delta B_y = 0.8432740\,\text{amp} \sin(kx)$
+  - $\delta B_z = 0.2981424\,\text{amp} \sin(kx)$
+- **Solver Setup**: Treated in hybrid PIC mode with kinetic ion particles ($nSpecies = 1$) and background electron fluid. Field solver is enabled (`solveEM = T`).
+- **Wave Propagation**: The fast magnetosonic speed is $v_{\text{fast}} = 2.0$. For wavelength $\lambda = 1.0$, the wave period is exactly $T_{\text{max}} = 0.5$.
+
+## Expected Results
+- **Particle Count Conservation**: The total number of particles must remain exactly constant (deviation $< 10^{-5}$).
+- **Kinetic Energy Stability**: The total kinetic energy must remain stable over the entire wave period (variation $< 10\%$), as the linear wave propagates without excessive numerical dissipation or grid heating.

--- a/tests/test_standalone/fast_wave/README.md
+++ b/tests/test_standalone/fast_wave/README.md
@@ -17,7 +17,7 @@ This is a standalone test designed to verify the propagation of a 1D linear adia
   - $\delta p = 0.4472136\,\text{amp} \sin(kx)$
   - $\delta B_y = 0.8432740\,\text{amp} \sin(kx)$
   - $\delta B_z = 0.2981424\,\text{amp} \sin(kx)$
-- **Solver Setup**: Treated in hybrid PIC mode with kinetic ion particles ($nSpecies = 1$) and background electron fluid. Field solver is enabled (`solveEM = T`).
+- **Solver Setup**: Treated in full PIC mode with kinetic electrons (Species 0) and kinetic ions (Species 1). Field solver is enabled (`solveEM = T`).
 - **Wave Propagation**: The fast magnetosonic speed is $v_{\text{fast}} = 2.0$. For wavelength $\lambda = 1.0$, the wave period is exactly $T_{\text{max}} = 0.5$.
 
 ## Expected Results

--- a/tests/test_standalone/ion_acoustic/PARAM.in
+++ b/tests/test_standalone/ion_acoustic/PARAM.in
@@ -1,0 +1,128 @@
+#DESCRIPTION
+1D Ion Acoustic Wave Standalone Test
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+0.0                    xMin
+6.283185307179586      xMax
+0.0                    yMin
+1.0                    yMax
+0.0                    zMin
+1.0                    zMax
+
+#NCELL
+512                     nCellX
+1                       nCellY
+1                       nCellZ
+
+#MAXBLOCKSIZE
+512                     maxBlockSizeX
+1                       maxBlockSizeY
+1                       maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#ELECTRON
+-100                    electronChargePerMass
+
+#PLASMA
+2                       nSpecies
+0.01                    mass
+-1.0                    charge
+1.0                     mass
+1.0                     charge
+
+#UNIFORMSTATE
+1.0e-6                  rho [amu/cc] (Species 0, Electrons)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+7.2429696e17            T [K]
+1.0e-4                  rho [amu/cc] (Species 1, Protons)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+3.6214848e16            T [K]
+0.0                     bx [T]
+0.0                     by [T]
+0.0                     bz [T]
+0.0                     ex [V/m]
+0.0                     ey [V/m]
+0.0                     ez [V/m]
+
+#WAVE
+rho0                    NameVar
+0.0                     Width
+0.01                    Amplitude
+6.283185307179586       LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+0.0                     Phase
+
+#WAVE
+rho1                    NameVar
+0.0                     Width
+0.01                    Amplitude
+6.283185307179586       LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+0.0                     Phase
+
+
+
+#TIMESTEPPING
+T                       useFixedDt
+0.01                    dt
+
+#DISCRETIZATION
+0.5                     theta
+0.0                     coefDiff
+
+#NORMALIZATION
+1.0                     lNormSI
+1.0                     uNormSI
+
+#MONITOR
+2                       dnReport
+
+#PARTICLES
+1000                    nParticle per cell in X
+1                       nParticle per cell in Y
+1                       nParticle per cell in Z
+
+#RANDOMPARTICLESLOCATION
+F                       isParticleLocationRandom
+
+#SMOOTHJ
+T                       doSmoothJ
+1                       nSmoothJ
+0.5                     coefSmoothJ
+
+#DIVE
+F                       doCorrectDivE
+
+#RESAMPLING
+F                       doReSampling
+
+#DIAGNOSTIC
+T                       doParticleDiag
+T                       doFieldDiag
+
+#SAVEPLOT
+1                                 nPlot
+z=0 fluid ascii pic               plotString
+-1                                dn
+0.5                               dt
+1                                 dx
+
+#STOP
+-1                      MaxIter
+12.0                    TimeMax

--- a/tests/test_standalone/ion_acoustic/README.md
+++ b/tests/test_standalone/ion_acoustic/README.md
@@ -1,0 +1,25 @@
+# Ion Acoustic Wave Standalone Test
+
+This test validates the 1D self-consistent low-frequency electrostatic Ion Acoustic Wave (IAW) in a warm plasma with $T_e \gg T_i$.
+
+## Background
+
+In an Ion Acoustic Wave, the massive ions provide the inertia, while the hot, mobile electrons provide the restoring pressure force. The wave speed in the long-wavelength limit is given by:
+$$ c_s = \sqrt{\frac{k_B T_e + \gamma_i k_B T_i}{m_i}} $$
+
+In our test setup:
+- Electron-to-ion mass ratio: $m_i / m_e = 100$ ($m_e = 0.01, m_i = 1.0$)
+- Initial temperatures: $T_e = 1.0$, $T_i = 0.05$ (yielding $T_e / T_i = 20$)
+- For $\gamma_i = 3$, this results in an ion acoustic speed of:
+  $$ c_s = \sqrt{1.0 + 3 \times 0.05} = \sqrt{1.15} \approx 1.07 $$
+- Wave vector: $k_x = 1.0$ (wavelength $\lambda = 2\pi$)
+- Wave frequency: $\omega = k_x c_s \approx 1.07$
+- Oscillation period: $T = 2\pi / \omega \approx 5.87$
+
+A small initial density perturbation is applied to the electrons (Species 0):
+$$ n_e(x, t=0) = 1.0 + 0.01 \cos(x) $$
+
+This density perturbation drives a self-consistent initial electric field:
+$$ E_x(x, t=0) = -4\pi \times 0.01 \sin(x) $$
+
+The simulation runs for $T_{\text{max}} = 12.0$, resolving $\approx 2$ full periods of the ion acoustic wave.

--- a/tests/test_standalone/langmuir/PARAM.in
+++ b/tests/test_standalone/langmuir/PARAM.in
@@ -1,0 +1,109 @@
+#DESCRIPTION
+1D Langmuir Wave Standalone Test
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+0.0                    xMin
+6.283185307179586      xMax
+0.0                    yMin
+1.0                    yMax
+0.0                    zMin
+1.0                    zMax
+
+#NCELL
+512                     nCellX
+1                       nCellY
+1                       nCellZ
+
+#MAXBLOCKSIZE
+512                     maxBlockSizeX
+1                       maxBlockSizeY
+1                       maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#ELECTRON
+-100                    electronChargePerMass
+
+#PLASMA
+2                       nSpecies
+0.01                    mass
+-1.0                    charge
+1.0                     mass
+1.0                     charge
+
+#UNIFORMSTATE
+1.0e-6                  rho [amu/cc] (Species 0, Electrons)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+0.0                     T [K]
+1.0e-4                  rho [amu/cc] (Species 1, Protons)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+0.0                     T [K]
+0.0                     bx [T]
+0.0                     by [T]
+0.0                     bz [T]
+0.0                     ex [V/m]
+0.0                     ey [V/m]
+0.0                     ez [V/m]
+
+#WAVE
+langmuir                waveType
+1.0                     waveAmp
+6.283185307179586       waveLength
+0.0                     waveAngle
+
+#TIMESTEPPING
+T                       useFixedDt
+0.01                    dt
+
+#DISCRETIZATION
+0.5                     theta
+0.0                     coefDiff
+
+#NORMALIZATION
+1.0                     lNormSI
+1.0                     uNormSI
+
+#MONITOR
+100                     dnReport
+
+#PARTICLES
+100                     nParticle per cell in X
+1                       nParticle per cell in Y
+1                       nParticle per cell in Z
+
+#RANDOMPARTICLESLOCATION
+F                       isParticleLocationRandom
+
+#DIVE
+F                       doCorrectDivE
+
+#RESAMPLING
+F                       doReSampling
+
+#DIAGNOSTIC
+T                       doParticleDiag
+T                       doFieldDiag
+
+#SAVEPLOT
+1                                 nPlot
+z=0 fluid ascii pic               plotString
+-1                                dn
+0.1                               dt
+1                                 dx
+
+#STOP
+-1                      MaxIter
+0.9                      TimeMax

--- a/tests/test_standalone/langmuir/PARAM.in
+++ b/tests/test_standalone/langmuir/PARAM.in
@@ -61,8 +61,9 @@ T                       solveEM
 #WAVE
 langmuir                waveType
 0.1                     waveAmp
-6.283185307179586       waveLength
-0.0                     waveAngle
+6.283185307179586       LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/langmuir/PARAM.in
+++ b/tests/test_standalone/langmuir/PARAM.in
@@ -60,7 +60,7 @@ T                       solveEM
 
 #WAVE
 langmuir                waveType
-1.0                     waveAmp
+0.1                     waveAmp
 6.283185307179586       waveLength
 0.0                     waveAngle
 
@@ -77,15 +77,20 @@ T                       useFixedDt
 1.0                     uNormSI
 
 #MONITOR
-100                     dnReport
+2                       dnReport
 
 #PARTICLES
-100                     nParticle per cell in X
+1000                    nParticle per cell in X
 1                       nParticle per cell in Y
 1                       nParticle per cell in Z
 
 #RANDOMPARTICLESLOCATION
 F                       isParticleLocationRandom
+
+#SMOOTHJ
+T                       doSmoothJ
+1                       nSmoothJ
+0.5                     coefSmoothJ
 
 #DIVE
 F                       doCorrectDivE
@@ -101,9 +106,9 @@ T                       doFieldDiag
 1                                 nPlot
 z=0 fluid ascii pic               plotString
 -1                                dn
-0.1                               dt
+0.08862269                        dt
 1                                 dx
 
 #STOP
 -1                      MaxIter
-0.9                      TimeMax
+0.70898154                      TimeMax

--- a/tests/test_standalone/langmuir/PARAM.in
+++ b/tests/test_standalone/langmuir/PARAM.in
@@ -59,11 +59,23 @@ T                       solveEM
 0.0                     ez [V/m]
 
 #WAVE
-langmuir                waveType
-0.1                     waveAmp
+rho0                    NameVar
+0.0                     Width
+0.1                     Amplitude
 6.283185307179586       LambdaX
 -1.0                    LambdaY
 -1.0                    LambdaZ
+0.0                     Phase
+
+#WAVE
+ex                      NameVar
+0.0                     Width
+-1.2566370614359172     Amplitude
+6.283185307179586       LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/langmuir/README.md
+++ b/tests/test_standalone/langmuir/README.md
@@ -1,0 +1,17 @@
+# Langmuir Wave Electrostatic Oscillation Test
+
+This test validates the 1D self-consistent electrostatic Langmuir wave oscillation in a cold, periodic plasma.
+
+## Background
+
+A small initial density perturbation is applied only to electrons (Species 0):
+$$ n_e(x, t=0) = 1.0 + 0.02 \cos(x) $$
+
+This density perturbation creates a charge imbalance that drives a self-consistent initial electric field:
+$$ E_x(x, t=0) = -0.02 \sin(x) $$
+
+The plasma will oscillate at the electron plasma frequency:
+$$ \omega_{pe} = \sqrt{\frac{n_0 e^2}{m_e \epsilon_0}} = 10.0 $$
+with oscillation period $T = 0.6283$.
+
+The total simulation time is $T_{\text{max}} = 100$, resolving $\approx 159$ periods of oscillation.

--- a/tests/test_standalone/langmuir/README.md
+++ b/tests/test_standalone/langmuir/README.md
@@ -4,14 +4,15 @@ This test validates the 1D self-consistent electrostatic Langmuir wave oscillati
 
 ## Background
 
-A small initial density perturbation is applied only to electrons (Species 0):
-$$ n_e(x, t=0) = 1.0 + 0.02 \cos(x) $$
+A small initial density perturbation is applied only to electrons (Species 0) using the parameter `waveAmp` (e.g. `0.1`):
+$$ n_e(x, t=0) = 1.0 + \text{waveAmp} \cos(x) $$
 
-This density perturbation creates a charge imbalance that drives a self-consistent initial electric field:
-$$ E_x(x, t=0) = -0.02 \sin(x) $$
+Under the Gaussian units solved by the PIC engine ($\epsilon_0 = 1 / 4\pi$), this density perturbation drives a self-consistent initial electric field:
+$$ E_x(x, t=0) = -4\pi \text{waveAmp} \sin(x) $$
 
 The plasma will oscillate at the electron plasma frequency:
-$$ \omega_{pe} = \sqrt{\frac{n_0 e^2}{m_e \epsilon_0}} = 10.0 $$
-with oscillation period $T = 0.6283$.
+$$ \omega_{pe} = \sqrt{\frac{4\pi n_0 q_e^2}{m_e}} \approx 35.45 $$
+for $n_0 = 1.0$, $q_e = -1.0$, $m_e = 0.01$. This yields an oscillation period of:
+$$ T = \frac{2\pi}{\omega_{pe}} \approx 0.177 $$
 
-The total simulation time is $T_{\text{max}} = 100$, resolving $\approx 159$ periods of oscillation.
+The total simulation time is $T_{\text{max}} = 0.9$, resolving $\approx 5$ full periods of oscillation.

--- a/tests/test_standalone/performance/PARAM.in
+++ b/tests/test_standalone/performance/PARAM.in
@@ -34,12 +34,19 @@ T                       solveEM
 -100                    electronChargePerMass
 
 #PLASMA
-1                       nSpecies
+2                       nSpecies
+0.01                    mass
+-1.0                    charge
 1.0                     mass
 1.0                     charge
 
 #UNIFORMSTATE
-5.0                     rho [amu/cc]
+0.05                    rho [amu/cc] (Species 0 electrons; n_e = n_i = 5/cc)
+-400.0                  ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+10000.0                 T [K]
+5.0                     rho [amu/cc] (Species 1 ions; n_i = 5/cc)
 -400.0                  ux [km/s]
 0.0                     uy [km/s]
 0.0                     uz [km/s]
@@ -53,7 +60,7 @@ T                       solveEM
 
 #TESTCASE
 Beam
-0                       iSpecies
+1                       iSpecies
 0.01                    ratio
 0.4                     vel
 0.0                     vel

--- a/tests/test_standalone/slow_wave/PARAM.in
+++ b/tests/test_standalone/slow_wave/PARAM.in
@@ -1,0 +1,89 @@
+#DESCRIPTION
+1D Adiabatic MHD Slow Wave Standalone Test
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+0.0                    xMin
+1.0                    xMax
+0.0                    yMin
+1.0                    yMax
+0.0                    zMin
+1.0                    zMax
+
+#NCELL
+64                      nCellX
+1                       nCellY
+1                       nCellZ
+
+#MAXBLOCKSIZE
+64                      maxBlockSizeX
+1                       maxBlockSizeY
+1                       maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#ELECTRON
+-100                    electronChargePerMass
+
+#PLASMA
+2                       nSpecies
+0.01                    mass
+-1.0                    charge
+1.0                     mass
+1.0                     charge
+
+#UNIFORMSTATE
+0.01                    rho [amu/cc] (Species 0)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+1000.0                  T [K]
+1.0                     rho [amu/cc] (Species 1)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+1000.0                  T [K]
+1.0                     bx [T]
+1.4142135623730951      by [T]
+0.5                     bz [T]
+0.0                     ex [V/m]
+0.0                     ey [V/m]
+0.0                     ez [V/m]
+
+#WAVE
+slow                    waveType
+0.5                       waveAmp
+1.0                     waveLength
+0.0                     waveAngle
+
+#TIMESTEPPING
+T                       useFixedDt
+0.01                    dt
+
+#NORMALIZATION
+1.0                     lNormSI
+1.0                     uNormSI
+
+#MONITOR
+1                       dnReport
+
+#PARTICLES
+100                     nParticle per cell in X
+1                       nParticle per cell in Y
+1                       nParticle per cell in Z
+
+#DIAGNOSTIC
+T                       doParticleDiag
+T                       doFieldDiag
+
+#STOP
+-1                      MaxIter
+2.0                     TimeMax

--- a/tests/test_standalone/slow_wave/PARAM.in
+++ b/tests/test_standalone/slow_wave/PARAM.in
@@ -59,11 +59,68 @@ T                       solveEM
 0.0                     ez [V/m]
 
 #WAVE
-slow                    waveType
-0.5                       waveAmp
+rho                     NameVar
+0.0                     Width
+0.4472135954999580      Amplitude
 1.0                     LambdaX
 -1.0                    LambdaY
 -1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+ux                      NameVar
+0.0                     Width
+-0.2236067977499790     Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+uy                      NameVar
+0.0                     Width
+-0.4216370213557840     Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+uz                      NameVar
+0.0                     Width
+-0.1490711984999860     Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+p                       NameVar
+0.0                     Width
+0.4472135954999580      Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+by                      NameVar
+0.0                     Width
+-0.2108185106778920     Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+bz                      NameVar
+0.0                     Width
+-0.0745355992499930     Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/slow_wave/PARAM.in
+++ b/tests/test_standalone/slow_wave/PARAM.in
@@ -61,8 +61,9 @@ T                       solveEM
 #WAVE
 slow                    waveType
 0.5                       waveAmp
-1.0                     waveLength
-0.0                     waveAngle
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/slow_wave/README.md
+++ b/tests/test_standalone/slow_wave/README.md
@@ -1,0 +1,25 @@
+# 1D Adiabatic MHD Slow Wave Test
+
+## Description
+This is a standalone test designed to verify the propagation of a 1D linear adiabatic MHD slow magnetosonic wave in FLEKS. The test initializes self-consistent perturbations in both the kinetic ion particles and electromagnetic fields on a periodic grid, simulating wave propagation over exactly one wave period.
+
+## Physics & Solver Setup
+- **Geometry & Boundaries**: 1D periodic grid (64 cells in $X$, 1 in $Y$ and $Z$).
+- **Background State (Normalized)**: 
+  - Ion density $\rho_0 = 1.0$, pressure $p_0 = 0.6$ ($\gamma = 5/3$), bulk velocity $\vec{u}_0 = (0.0, 0.0, 0.0)$.
+  - Guiding magnetic field $\vec{B}_0 = (1.0, \sqrt{2.0}, 0.5)$.
+- **Perturbations (Eigenfunctions)**:
+  - Perturbation amplitude $\text{amp} = 10^{-4}$, wavelength $\lambda = 1.0$.
+  - $\delta \rho = 0.8944272\,\text{amp} \sin(kx)$
+  - $\delta u_x = -0.4472136\,\text{amp} \sin(kx)$
+  - $\delta u_y = -0.8432740\,\text{amp} \sin(kx)$
+  - $\delta u_z = -0.2981424\,\text{amp} \sin(kx)$
+  - $\delta p = 0.8944272\,\text{amp} \sin(kx)$
+  - $\delta B_y = -0.4216370\,\text{amp} \sin(kx)$
+  - $\delta B_z = -0.1490712\,\text{amp} \sin(kx)$
+- **Solver Setup**: Treated in hybrid PIC mode with kinetic ion particles ($nSpecies = 1$) and background electron fluid. Field solver is enabled (`solveEM = T`).
+- **Wave Propagation**: The slow magnetosonic speed is $v_{\text{slow}} = 0.5$. For wavelength $\lambda = 1.0$, the wave period is exactly $T_{\text{max}} = 2.0$.
+
+## Expected Results
+- **Particle Count Conservation**: The total number of particles must remain exactly constant (deviation $< 10^{-5}$).
+- **Kinetic Energy Stability**: The total kinetic energy must remain stable over the entire wave period (variation $< 10\%$), as the linear wave propagates without excessive numerical dissipation or grid heating.

--- a/tests/test_standalone/slow_wave/README.md
+++ b/tests/test_standalone/slow_wave/README.md
@@ -17,7 +17,7 @@ This is a standalone test designed to verify the propagation of a 1D linear adia
   - $\delta p = 0.8944272\,\text{amp} \sin(kx)$
   - $\delta B_y = -0.4216370\,\text{amp} \sin(kx)$
   - $\delta B_z = -0.1490712\,\text{amp} \sin(kx)$
-- **Solver Setup**: Treated in hybrid PIC mode with kinetic ion particles ($nSpecies = 1$) and background electron fluid. Field solver is enabled (`solveEM = T`).
+- **Solver Setup**: Treated in full PIC mode with kinetic electrons (Species 0) and kinetic ions (Species 1). Field solver is enabled (`solveEM = T`).
 - **Wave Propagation**: The slow magnetosonic speed is $v_{\text{slow}} = 0.5$. For wavelength $\lambda = 1.0$, the wave period is exactly $T_{\text{max}} = 2.0$.
 
 ## Expected Results

--- a/tests/test_standalone/sound_wave/PARAM.in
+++ b/tests/test_standalone/sound_wave/PARAM.in
@@ -59,11 +59,32 @@ T                       solveEM
 0.0                     ez [V/m]
 
 #WAVE
-sound                   waveType
-0.1                     waveAmp
+rho                     NameVar
+0.0                     Width
+0.1                     Amplitude
 1.0                     LambdaX
 -1.0                    LambdaY
 -1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+ux                      NameVar
+0.0                     Width
+-0.1                    Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
+#WAVE
+p                       NameVar
+0.0                     Width
+0.1                     Amplitude
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
+-90.0                   Phase
+
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/sound_wave/PARAM.in
+++ b/tests/test_standalone/sound_wave/PARAM.in
@@ -1,0 +1,96 @@
+#DESCRIPTION
+1D Adiabatic Hydrodynamic (Sound) Wave Standalone Test
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+0.0                    xMin
+1.0                    xMax
+0.0                    yMin
+1.0                    yMax
+0.0                    zMin
+1.0                    zMax
+
+#NCELL
+64                      nCellX
+1                       nCellY
+1                       nCellZ
+
+#MAXBLOCKSIZE
+64                      maxBlockSizeX
+1                       maxBlockSizeY
+1                       maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#ELECTRON
+-100                    electronChargePerMass
+
+#PLASMA
+2                       nSpecies
+0.01                    mass
+-1.0                    charge
+1.0                     mass
+1.0                     charge
+
+#UNIFORMSTATE
+0.01                    rho [amu/cc] (Species 0)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+1000.0                  T [K]
+1.0                     rho [amu/cc] (Species 1)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+1000.0                  T [K]
+0.0                     bx [T]
+0.0                     by [T]
+0.0                     bz [T]
+0.0                     ex [V/m]
+0.0                     ey [V/m]
+0.0                     ez [V/m]
+
+#WAVE
+sound                   waveType
+0.1                     waveAmp
+1.0                     waveLength
+0.0                     waveAngle
+
+#TIMESTEPPING
+T                       useFixedDt
+0.01                    dt
+
+#NORMALIZATION
+1.0                     lNormSI
+1.0                     uNormSI
+
+#MONITOR
+1                       dnReport
+
+#PARTICLES
+100                     nParticle per cell in X
+1                       nParticle per cell in Y
+1                       nParticle per cell in Z
+
+#DIAGNOSTIC
+T                       doParticleDiag
+T                       doFieldDiag
+
+#SAVEPLOT
+1                                 nPlot
+z=0 fluid ascii pic               plotString
+-1                                dn
+0.1                               dt
+1                                 dx
+
+#STOP
+-1                      MaxIter
+1.0                     TimeMax

--- a/tests/test_standalone/sound_wave/PARAM.in
+++ b/tests/test_standalone/sound_wave/PARAM.in
@@ -61,8 +61,9 @@ T                       solveEM
 #WAVE
 sound                   waveType
 0.1                     waveAmp
-1.0                     waveLength
-0.0                     waveAngle
+1.0                     LambdaX
+-1.0                    LambdaY
+-1.0                    LambdaZ
 
 #TIMESTEPPING
 T                       useFixedDt

--- a/tests/test_standalone/sound_wave/README.md
+++ b/tests/test_standalone/sound_wave/README.md
@@ -13,7 +13,7 @@ This is a standalone test designed to verify the propagation of a 1D linear adia
   - $\delta \rho = \text{amp} \sin(kx)$
   - $\delta u_x = -\text{amp} \sin(kx)$
   - $\delta p = \text{amp} \sin(kx)$
-- **Solver Setup**: Treated in hybrid PIC mode with kinetic ion particles ($nSpecies = 1$) and background electron fluid. Field solver is enabled (`solveEM = T`).
+- **Solver Setup**: Treated in full PIC mode with kinetic electrons (Species 0) and kinetic ions (Species 1). Field solver is enabled (`solveEM = T`).
 - **Wave Propagation**: The phase speed is $v_{\text{phase}} = \sqrt{\gamma p_0 / \rho_0} = 1.0$, meaning the wave travels exactly one period at $T_{\text{max}} = 1.0$.
 
 ## Expected Results

--- a/tests/test_standalone/sound_wave/README.md
+++ b/tests/test_standalone/sound_wave/README.md
@@ -1,0 +1,21 @@
+# 1D Adiabatic Hydrodynamic (Sound) Wave Test
+
+## Description
+This is a standalone test designed to verify the propagation of a 1D linear adiabatic hydrodynamic sound wave in FLEKS. The test initializes a spatial sine perturbation on the grid, which naturally loads self-consistent perturbations in the ion particles and electromagnetic fields, and simulates wave propagation over exactly one wave period.
+
+## Physics & Solver Setup
+- **Geometry & Boundaries**: 1D periodic grid (64 cells in $X$, 1 in $Y$ and $Z$).
+- **Background State (Normalized)**: 
+  - Ion density $\rho_0 = 1.0$, pressure $p_0 = 0.6$ ($\gamma = 5/3$), and zero bulk velocity.
+  - Guiding magnetic field $\vec{B}_0 = (0.0, 0.0, 0.0)$.
+- **Perturbations (Eigenfunctions)**:
+  - Perturbation amplitude $\text{amp} = 10^{-4}$, wavelength $\lambda = 1.0$.
+  - $\delta \rho = \text{amp} \sin(kx)$
+  - $\delta u_x = -\text{amp} \sin(kx)$
+  - $\delta p = \text{amp} \sin(kx)$
+- **Solver Setup**: Treated in hybrid PIC mode with kinetic ion particles ($nSpecies = 1$) and background electron fluid. Field solver is enabled (`solveEM = T`).
+- **Wave Propagation**: The phase speed is $v_{\text{phase}} = \sqrt{\gamma p_0 / \rho_0} = 1.0$, meaning the wave travels exactly one period at $T_{\text{max}} = 1.0$.
+
+## Expected Results
+- **Particle Count Conservation**: The total number of particles must remain exactly constant (deviation $< 10^{-5}$).
+- **Kinetic Energy Stability**: The total kinetic energy must remain stable over the entire wave period (variation $< 10\%$), as the linear wave propagates without excessive numerical dissipation or grid heating.

--- a/tests/test_standalone/tophat/PARAM.in
+++ b/tests/test_standalone/tophat/PARAM.in
@@ -1,0 +1,86 @@
+#DESCRIPTION
+1D Electromagnetic TopHat Wave Standalone Test
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+-1.0                    xMin
+ 1.0                    xMax
+-1.0                    yMin
+ 1.0                    yMax
+-1.0                    zMin
+ 1.0                    zMax
+
+#NCELL
+64                      nCellX
+ 1                      nCellY
+ 1                      nCellZ
+
+#MAXBLOCKSIZE
+64                      maxBlockSizeX
+ 1                      maxBlockSizeY
+ 1                      maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#PLASMA
+2                       nSpecies
+0.01                    mass
+-1.0                    charge
+1.0                     mass
+1.0                     charge
+
+#TESTCASE
+tophat                  testCase
+
+#TIMESTEPPING
+T                       useFixedDt
+0.01                    dt
+
+#NORMALIZATION
+1.0                     lNormSI
+1.0                     uNormSI
+
+#MONITOR
+1                       dnReport
+
+#UPWINDE
+T                       useUpwindE
+1                       limiterTheta
+
+#UPWINDB
+T                       doSmoothB
+1                       theta
+
+#EFIELDSOLVER
+1.0e-6                  EFieldTol
+200                     EFieldIter
+
+#DIVE
+T
+1
+
+#SAVEPLOT
+1                                 nPlot
+z=0 fluid ascii pic               plotString
+-1                                dn
+2.0                               dt
+1                                 dx
+
+#DIAGNOSTIC
+F                    doParticleDiag
+T                    doFieldDiag
+
+#STOP
+-1                      MaxIter
+2.0                     TimeMax
+
+#RUN
+

--- a/tests/test_standalone/tophat/README.md
+++ b/tests/test_standalone/tophat/README.md
@@ -1,0 +1,18 @@
+# 1D Electromagnetic Top-Hat Wave Propagation Test
+
+## Description
+This is a standalone test designed to verify the physical propagation of a 1D electromagnetic square (top-hat) pulse in a periodic domain, benchmarked against low-dispersion/low-diffusion properties of the field solver in FLEKS.
+
+## Physics & Solver Setup
+- **Geometry & Boundaries**: 1D periodic grid ($x \in [-1.0, 1.0]$, 64 cells in $X$, 1 in $Y$ and $Z$).
+- **Physical Model**: Pure electromagnetic field propagation. No kinetic particles are initialized (`nPartPerCell = IntVect::Zero`), meaning the plasma density is effectively zero and there are no particle effects.
+- **Initial Fields**: A square top-hat pulse is initialized in the central 50% region ($[-0.5, 0.5]$):
+  - $E_y = 1.0$
+  - $B_z = 1.0$
+  - Outside this interval, all fields are set to $0.0$.
+- **Electromagnetic Fields**: Field solver is enabled (`solveEM = T`) with standard explicit/implicit discretization parameters.
+- **Propagation Dynamics**: In normalized units with speed of light $c = 1$, the initial state represents a pure right-going transverse wave pulse. Over time, the top-hat pulse propagates to the right at speed $v = 1.0$ while keeping its shape.
+
+## Expected Results
+- **Amplitude Retention**: The peak magnetic field $B_z$ must remain close to $1.0$ (subject to minor numerical dispersion/diffusion of the square shape on a discrete grid, typically in the range $[0.8, 1.2]$).
+- **Decoupled Fields**: The transverse magnetic field component $B_y$ must remain negligible (near $0.0$) throughout the run, confirming there is no unphysical cross-coupling of wave modes.

--- a/tests/test_standalone/validate_tests.py
+++ b/tests/test_standalone/validate_tests.py
@@ -156,12 +156,15 @@ def read_diag_log(run_dir):
 
         if has_field and col + 1 < len(vals):
             try:
-                field_diags.append({
+                diag_dict = {
                     "time":   t,
                     "cycle":  cycle,
                     "max_by": float(vals[col]),
                     "max_bz": float(vals[col + 1]),
-                })
+                }
+                if col + 2 < len(vals):
+                    diag_dict["max_ey"] = float(vals[col + 2])
+                field_diags.append(diag_dict)
             except ValueError:
                 pass
 
@@ -713,6 +716,55 @@ def validate_slow_wave(diags):
     return validate_sound_wave(diags)
 
 
+def validate_tophat(diags, field_diags=None):
+    print("Validating TopHat Test...")
+    if not field_diags:
+        print("FAIL: No field diagnostic outputs parsed.")
+        return False, "No field diagnostics parsed"
+    
+    passed = True
+    reasons = []
+    
+    for diag in field_diags:
+        t = diag["time"]
+        max_bz = diag["max_bz"]
+        max_by = diag["max_by"]
+        max_ey = diag.get("max_ey", None)
+        
+        # max_bz should remain close to 1.0 (allow [0.8, 1.2])
+        if max_bz < 0.8 or max_bz > 1.2:
+            print(f"  FAIL at t={t:.2f}: maxBz is outside acceptable range [0.8, 1.2]! Actual={max_bz:.3f}")
+            passed = False
+            reasons.append(f"maxBz outside range at t={t:.2f}")
+
+        # max_ey should remain close to 1.0 (allow [0.8, 1.2])
+        if max_ey is not None and (max_ey < 0.8 or max_ey > 1.2):
+            print(f"  FAIL at t={t:.2f}: maxEy is outside acceptable range [0.8, 1.2]! Actual={max_ey:.3f}")
+            passed = False
+            reasons.append(f"maxEy outside range at t={t:.2f}")
+            
+        # max_by should remain near 0.0 (allow <= 0.05)
+        if max_by > 0.05:
+            print(f"  FAIL at t={t:.2f}: maxBy is too high! Actual={max_by:.3f}")
+            passed = False
+            reasons.append(f"maxBy too high at t={t:.2f}")
+            
+    if passed:
+        # Print actual initial/final values to confirm validation
+        if len(field_diags) > 0:
+            init_bz = field_diags[0]["max_bz"]
+            init_ey = field_diags[0].get("max_ey", 0.0)
+            final_bz = field_diags[-1]["max_bz"]
+            final_ey = field_diags[-1].get("max_ey", 0.0)
+            print(f"  Initial Fields: maxBz={init_bz:.3f}, maxEy={init_ey:.3f}")
+            print(f"  Final Fields:   maxBz={final_bz:.3f}, maxEy={final_ey:.3f}")
+        print("TopHat Test: PASSED")
+        return True, "Passed"
+    else:
+        return False, "; ".join(reasons)
+
+
+
 def ensure_flekspy_installed():
     try:
         import flekspy
@@ -823,7 +875,8 @@ def main():
         "sound_wave": validate_sound_wave,
         "fast_wave": validate_fast_wave,
         "alfven_wave": validate_alfven_wave,
-        "slow_wave": validate_slow_wave
+        "slow_wave": validate_slow_wave,
+        "tophat": validate_tophat
     }
     
     # Discover test subdirectories under tests/test_standalone
@@ -867,7 +920,7 @@ def main():
             # Read diagnostics from the structured log file (preferred) or fall back
             # to parsing stdout for backward compatibility.
             particle_diags, field_diags = read_diag_log("run_test")
-            if not particle_diags:
+            if not particle_diags and not field_diags:
                 print("  [INFO] No log file found; falling back to stdout parsing.")
                 particle_diags, field_diags = parse_diagnostics(stdout)
 

--- a/tests/test_standalone/validate_tests.py
+++ b/tests/test_standalone/validate_tests.py
@@ -20,7 +20,10 @@ def prepare_run_dir():
     
     # Symlinks in run directory
     safe_symlink("../bin/FLEKS.exe", os.path.join(run_dir, "FLEKS.exe"))
-    safe_symlink("../../../share/Scripts/PostProc.pl", os.path.join(run_dir, "PostProc.pl"))
+    if os.path.exists("share/Scripts/PostProc.pl"):
+        safe_symlink("../share/Scripts/PostProc.pl", os.path.join(run_dir, "PostProc.pl"))
+    else:
+        safe_symlink("../../../share/Scripts/PostProc.pl", os.path.join(run_dir, "PostProc.pl"))
     
     # Component plot and restart directories
     pc_dir = os.path.join(run_dir, "PC")
@@ -29,8 +32,15 @@ def prepare_run_dir():
     os.makedirs(os.path.join(pc_dir, "restartOUT"), exist_ok=True)
     
     # Symlinks in component directory
-    safe_symlink("../../../../share/Scripts/pIDL", os.path.join(pc_dir, "pIDL"))
-    safe_symlink("../../../../bin/PostIDL.exe", os.path.join(pc_dir, "PostIDL.exe"))
+    if os.path.exists("share/Scripts/pIDL"):
+        safe_symlink("../../share/Scripts/pIDL", os.path.join(pc_dir, "pIDL"))
+    else:
+        safe_symlink("../../../../share/Scripts/pIDL", os.path.join(pc_dir, "pIDL"))
+        
+    if os.path.exists("bin/PostIDL.exe"):
+        safe_symlink("../../bin/PostIDL.exe", os.path.join(pc_dir, "PostIDL.exe"))
+    else:
+        safe_symlink("../../../../bin/PostIDL.exe", os.path.join(pc_dir, "PostIDL.exe"))
 
 def cleanup_run_dir():
     """Remove simulation output files from run_test/ after each test.
@@ -715,6 +725,10 @@ def validate_slow_wave(diags):
     print("Validating Slow Wave Test...")
     return validate_sound_wave(diags)
 
+def validate_anisotropic_wave(diags):
+    print("Validating Anisotropic MHD Wave Test...")
+    return validate_sound_wave(diags)
+
 
 def validate_langmuir(diags):
     print("Validating Langmuir Wave Electrostatic Oscillation Test...")
@@ -945,6 +959,7 @@ def main():
         "fast_wave": validate_fast_wave,
         "alfven_wave": validate_alfven_wave,
         "slow_wave": validate_slow_wave,
+        "anisotropic_wave": validate_anisotropic_wave,
         "tophat": validate_tophat,
         "langmuir": validate_langmuir
     }

--- a/tests/test_standalone/validate_tests.py
+++ b/tests/test_standalone/validate_tests.py
@@ -746,8 +746,10 @@ def validate_langmuir(diags):
         with open("run_test/PARAM.in", "r") as f:
             lines = f.readlines()
             for idx, line in enumerate(lines):
-                if "waveAmp" in line:
-                    wave_amp = float(line.split()[0])
+                if "waveAmp" in line or ("Amplitude" in line and wave_amp == 0.02):
+                    val = float(line.split()[0])
+                    if abs(val) > 0.001:  # ignore extremely small perturbations
+                        wave_amp = abs(val)
                 if "#PLASMA" in line:
                     m_e = float(lines[idx + 2].split()[0])
     except Exception:

--- a/tests/test_standalone/validate_tests.py
+++ b/tests/test_standalone/validate_tests.py
@@ -716,6 +716,75 @@ def validate_slow_wave(diags):
     return validate_sound_wave(diags)
 
 
+def validate_langmuir(diags):
+    print("Validating Langmuir Wave Electrostatic Oscillation Test...")
+    if not diags:
+        print("FAIL: No diagnostic outputs parsed.")
+        return False, "No diagnostic outputs parsed"
+
+    passed = True
+    reasons = []
+
+    from collections import defaultdict
+    by_species = defaultdict(list)
+    for d in diags:
+        by_species[d["species"]].append(d)
+
+    for iS, species_diags in sorted(by_species.items()):
+        if not species_diags:
+            continue
+
+        # 1. Particle count conservation
+        initial_phys = species_diags[0]["phys"]
+        for diag in species_diags:
+            t = diag["time"]
+            actual_phys = diag["phys"]
+            if initial_phys > 0 and abs(actual_phys - initial_phys) > 1e-5 * initial_phys:
+                print(f"  FAIL species {iS} at t={t:.2f}: Particle count changed! "
+                      f"Expected={initial_phys:.2e}, Actual={actual_phys:.2e}")
+                passed = False
+                reasons.append(f"Species {iS} particle count changed at t={t:.2f}")
+
+        # 2. Bulk velocity for heavy protons (species 1) should stay near zero
+        if iS == 1:
+            for diag in species_diags:
+                t = diag["time"]
+                vx = diag["vx"]
+                if abs(vx) > 0.01:
+                    print(f"  FAIL species {iS} (protons) at t={t:.2f}: Bulk vx deviated! "
+                          f"Expected ~0.0, Actual={vx:.4f}")
+                    passed = False
+                    reasons.append(f"Species {iS} proton vx deviated at t={t:.2f}")
+
+    # 3. Check electron KE oscillates but stays bounded
+    electron_diags = by_species.get(0, [])
+    if electron_diags:
+        ke_vals = [d["ke"] for d in electron_diags]
+        max_ke = max(ke_vals)
+        min_ke = min(ke_vals)
+        # KE should oscillate between 0 and initial electrostatic energy
+        # Initial E field energy ~ 0.5 * (0.02)^2 * L / 2 = 0.5 * 4e-4 * pi ~ 6.3e-4
+        # In normalized units, check KE stays bounded (not growing = no numerical heating)
+        # Check that max_ke is bounded (e.g., < 0.01) to ensure no numerical heating/explosion,
+        # but also oscillates (reaches at least 1e-4) to ensure the wave is active.
+        if max_ke > 0.01:
+            print(f"  FAIL electrons: KE grew too large! Max KE={max_ke:.4e}")
+            passed = False
+            reasons.append(f"Electron KE grew too large: {max_ke:.4e}")
+        elif max_ke < 1e-4:
+            print(f"  FAIL electrons: KE too small, wave might be dead! Max KE={max_ke:.4e}")
+            passed = False
+            reasons.append(f"Electron KE too small: {max_ke:.4e}")
+        else:
+            print(f"  SUCCESS: Electron KE bounded and active [{min_ke:.4e}, {max_ke:.4e}]")
+
+    if passed:
+        print("Langmuir Wave Test: PASSED")
+        return True, "Passed"
+    else:
+        return False, "; ".join(reasons)
+
+
 def validate_tophat(diags, field_diags=None):
     print("Validating TopHat Test...")
     if not field_diags:
@@ -876,7 +945,8 @@ def main():
         "fast_wave": validate_fast_wave,
         "alfven_wave": validate_alfven_wave,
         "slow_wave": validate_slow_wave,
-        "tophat": validate_tophat
+        "tophat": validate_tophat,
+        "langmuir": validate_langmuir
     }
     
     # Discover test subdirectories under tests/test_standalone

--- a/tests/test_standalone/validate_tests.py
+++ b/tests/test_standalone/validate_tests.py
@@ -815,6 +815,62 @@ def validate_langmuir(diags):
         return False, "; ".join(reasons)
 
 
+def validate_ion_acoustic(diags):
+    print("Validating Ion Acoustic Wave (IAW) Test...")
+    if not diags:
+        print("FAIL: No diagnostic outputs parsed.")
+        return False, "No diagnostic outputs parsed"
+
+    passed = True
+    reasons = []
+
+    from collections import defaultdict
+    by_species = defaultdict(list)
+    for d in diags:
+        by_species[d["species"]].append(d)
+
+    for iS, species_diags in sorted(by_species.items()):
+        if not species_diags:
+            continue
+
+        # 1. Particle count conservation
+        initial_phys = species_diags[0]["phys"]
+        for diag in species_diags:
+            t = diag["time"]
+            actual_phys = diag["phys"]
+            if initial_phys > 0 and abs(actual_phys - initial_phys) > 1e-5 * initial_phys:
+                print(f"  FAIL species {iS} at t={t:.2f}: Particle count changed! "
+                      f"Expected={initial_phys:.2e}, Actual={actual_phys:.2e}")
+                passed = False
+                reasons.append(f"Species {iS} particle count changed at t={t:.2f}")
+
+        # 2. Check that bulk velocity vx oscillates (non-zero and bounded)
+        vx_vals = [d["vx"] for d in species_diags]
+        max_abs_vx = max(abs(vx) for vx in vx_vals)
+        print(f"  Species {iS} max|vx| = {max_abs_vx:.6f}")
+
+        min_limit = 0.002 if iS == 0 else 0.0001
+        max_limit = 0.05 if iS == 0 else 0.005
+
+        if max_abs_vx < min_limit:
+            print(f"  FAIL species {iS}: Wave is dead or bulk velocity did not oscillate! Max |vx|={max_abs_vx:.6f} (expected > {min_limit:.6f})")
+            passed = False
+            reasons.append(f"Species {iS} wave is inactive/dead (max |vx| too small)")
+        elif max_abs_vx > max_limit:
+            print(f"  FAIL species {iS}: Wave bulk velocity blew up! Max |vx|={max_abs_vx:.6f} (expected < {max_limit:.6f})")
+            passed = False
+            reasons.append(f"Species {iS} wave blew up (max |vx| too large)")
+        else:
+            print(f"  SUCCESS: Species {iS} wave active and bounded.")
+
+    if passed:
+        print("Ion Acoustic Wave Test: PASSED")
+        return True, "Passed"
+    else:
+        return False, "; ".join(reasons)
+
+
+
 def validate_tophat(diags, field_diags=None):
     print("Validating TopHat Test...")
     if not field_diags:
@@ -977,7 +1033,8 @@ def main():
         "slow_wave": validate_slow_wave,
         "anisotropic_wave": validate_anisotropic_wave,
         "tophat": validate_tophat,
-        "langmuir": validate_langmuir
+        "langmuir": validate_langmuir,
+        "ion_acoustic": validate_ion_acoustic
     }
     
     # Discover test subdirectories under tests/test_standalone

--- a/tests/test_standalone/validate_tests.py
+++ b/tests/test_standalone/validate_tests.py
@@ -739,6 +739,24 @@ def validate_langmuir(diags):
     passed = True
     reasons = []
 
+    # Parse waveAmp and electron mass dynamically from run_test/PARAM.in
+    wave_amp = 0.02  # default fallback
+    m_e = 0.01       # default fallback
+    try:
+        with open("run_test/PARAM.in", "r") as f:
+            lines = f.readlines()
+            for idx, line in enumerate(lines):
+                if "waveAmp" in line:
+                    wave_amp = float(line.split()[0])
+                if "#PLASMA" in line:
+                    m_e = float(lines[idx + 2].split()[0])
+    except Exception:
+        pass
+
+    # Total electrostatic energy in Gaussian units: W_E = 2 * pi^2 * waveAmp^2
+    # The logged KE is sum(0.5 * v^2 * weight), which is equivalent to total physical KE / mass.
+    expected_max_ke = 2.0 * (math.pi**2) * (wave_amp**2) / m_e
+
     from collections import defaultdict
     by_species = defaultdict(list)
     for d in diags:
@@ -776,21 +794,17 @@ def validate_langmuir(diags):
         ke_vals = [d["ke"] for d in electron_diags]
         max_ke = max(ke_vals)
         min_ke = min(ke_vals)
-        # KE should oscillate between 0 and initial electrostatic energy
-        # Initial E field energy ~ 0.5 * (0.02)^2 * L / 2 = 0.5 * 4e-4 * pi ~ 6.3e-4
-        # In normalized units, check KE stays bounded (not growing = no numerical heating)
-        # Check that max_ke is bounded (e.g., < 0.01) to ensure no numerical heating/explosion,
-        # but also oscillates (reaches at least 1e-4) to ensure the wave is active.
-        if max_ke > 0.01:
-            print(f"  FAIL electrons: KE grew too large! Max KE={max_ke:.4e}")
+        # Verify KE stays bounded and oscillates dynamically
+        if max_ke > 2.0 * expected_max_ke:
+            print(f"  FAIL electrons: KE grew too large! Max KE={max_ke:.4e} (expected ~{expected_max_ke:.4e})")
             passed = False
             reasons.append(f"Electron KE grew too large: {max_ke:.4e}")
-        elif max_ke < 1e-4:
-            print(f"  FAIL electrons: KE too small, wave might be dead! Max KE={max_ke:.4e}")
+        elif max_ke < 0.5 * expected_max_ke:
+            print(f"  FAIL electrons: KE too small, wave might be dead! Max KE={max_ke:.4e} (expected ~{expected_max_ke:.4e})")
             passed = False
             reasons.append(f"Electron KE too small: {max_ke:.4e}")
         else:
-            print(f"  SUCCESS: Electron KE bounded and active [{min_ke:.4e}, {max_ke:.4e}]")
+            print(f"  SUCCESS: Electron KE bounded and active [{min_ke:.4e}, {max_ke:.4e}] (expected max ~{expected_max_ke:.4e})")
 
     if passed:
         print("Langmuir Wave Test: PASSED")

--- a/tests/test_standalone/validate_tests.py
+++ b/tests/test_standalone/validate_tests.py
@@ -63,7 +63,11 @@ def run_test(test_dir):
     shutil.copy(param_file, "run_test/PARAM.in")
     
     # Run ./FLEKS.exe inside run_test/
-    result = subprocess.run(["./FLEKS.exe"], cwd="run_test", stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    cmd = ["./FLEKS.exe"]
+    if "sound_wave" in test_dir:
+        cmd = ["mpiexec", "-n", "2", "./FLEKS.exe"]
+        
+    result = subprocess.run(cmd, cwd="run_test", stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     if result.returncode != 0:
         print(f"Error running FLEKS.exe for {test_dir}:")
         print(result.stderr)

--- a/tests/test_standalone/validate_tests.py
+++ b/tests/test_standalone/validate_tests.py
@@ -551,21 +551,36 @@ def validate_beam(diags, field_diags=None):
 
     passed = True
     reasons = []
-    
-    # 1. Total particle count conservation check
-    initial_phys = diags[0]["phys"]
-    for diag in diags:
-        t = diag["time"]
-        actual_phys = diag["phys"]
-        if abs(actual_phys - initial_phys) > 1e-5 * initial_phys:
-            print(f"  FAIL at t={t:.2f}: Particle number changed! Expected={initial_phys:.2e}, Actual={actual_phys:.2e}")
-            passed = False
-            reasons.append(f"Particle number changed at t={t:.2f} (expected {initial_phys:.2e}, actual {actual_phys:.2e})")
 
-    # 2. Mean velocity conservation check
-    # Expected MeanVx is -0.392 (due to 99% background at -0.4 and 1% beam at +0.4)
+    # Group diagnostics by species independently.
+    from collections import defaultdict
+    by_species = defaultdict(list)
+    for d in diags:
+        by_species[d["species"]].append(d)
+
+    # 1. Particle count conservation per species
+    for iS, species_diags in sorted(by_species.items()):
+        if not species_diags:
+            continue
+        initial_phys = species_diags[0]["phys"]
+        for diag in species_diags:
+            t = diag["time"]
+            actual_phys = diag["phys"]
+            if initial_phys > 0 and abs(actual_phys - initial_phys) > 1e-5 * initial_phys:
+                print(f"  FAIL species {iS} at t={t:.2f}: Particle count changed! "
+                      f"Expected={initial_phys:.2e}, Actual={actual_phys:.2e}")
+                passed = False
+                reasons.append(f"Species {iS} particle count changed at t={t:.2f} "
+                               f"(expected {initial_phys:.2e}, actual {actual_phys:.2e})")
+
+    # 2. Mean velocity conservation check on the ion species (species 1).
+    # Expected MeanVx is -0.392 (99% background at -0.4, 1% beam at +0.4).
+    ion_diags = by_species.get(1, [])
+    if not ion_diags:
+        # Fallback: single-species run (legacy); use species 0
+        ion_diags = by_species.get(0, [])
     expected_vx = -0.392
-    for diag in diags:
+    for diag in ion_diags:
         t = diag["time"]
         actual_vx = diag["vx"]
         relative_diff = abs(actual_vx - expected_vx)
@@ -622,6 +637,76 @@ def validate_beam(diags, field_diags=None):
         return True, "Passed"
     else:
         return False, "; ".join(reasons)
+
+
+def validate_sound_wave(diags, is_cold=False):
+    print("Validating Sound Wave Test..." if not is_cold else "Validating Cold Wave Test...")
+    if not diags:
+        print("FAIL: No diagnostic outputs parsed.")
+        return False, "No diagnostic outputs parsed"
+    
+    passed = True
+    reasons = []
+    
+    # Group diagnostics by species so we check each species independently.
+    # diags is a flat list with entries for every species at every timestep.
+    from collections import defaultdict
+    by_species = defaultdict(list)
+    for d in diags:
+        by_species[d["species"]].append(d)
+
+    for iS, species_diags in sorted(by_species.items()):
+        if not species_diags:
+            continue
+        # 1. Particle count conservation per species
+        initial_phys = species_diags[0]["phys"]
+        for diag in species_diags:
+            t = diag["time"]
+            actual_phys = diag["phys"]
+            if initial_phys > 0 and abs(actual_phys - initial_phys) > 1e-5 * initial_phys:
+                print(f"  FAIL species {iS} at t={t:.2f}: Particle count changed! "
+                      f"Expected={initial_phys:.2e}, Actual={actual_phys:.2e}")
+                passed = False
+                reasons.append(f"Species {iS} particle count changed at t={t:.2f}")
+
+        # 2. Kinetic energy stability per species
+        if is_cold:
+            # In a cold plasma (T=0), kinetic energy oscillates between magnetic energy and kinetic bulk energy.
+            # Light species (electrons) are also subject to numerical/grid heating. Therefore, we bypass
+            # the KE stability check for cold plasma wave tests.
+            continue
+
+        initial_ke = species_diags[0]["ke"]
+        ke_tol = 0.85 if iS == 0 else 0.20  # allow more slack for electrons (species 0) due to physical wave heating
+        for diag in species_diags:
+            t = diag["time"]
+            actual_ke = diag["ke"]
+            if initial_ke > 0:
+                diff_ke = abs(actual_ke - initial_ke) / initial_ke
+                if diff_ke > ke_tol:
+                    print(f"  FAIL species {iS} at t={t:.2f}: KE variation too large! "
+                          f"Expected={initial_ke:.2e}, Actual={actual_ke:.2e}, "
+                          f"diff={diff_ke*100:.2f}%")
+                    passed = False
+                    reasons.append(f"Species {iS} KE variation too large at t={t:.2f}")
+
+    if passed:
+        print("Wave Test: PASSED")
+        return True, "Passed"
+    else:
+        return False, "; ".join(reasons)
+
+def validate_fast_wave(diags):
+    print("Validating Fast Wave Test...")
+    return validate_sound_wave(diags)
+
+def validate_alfven_wave(diags):
+    print("Validating Alfven Wave Test...")
+    return validate_sound_wave(diags)
+
+def validate_slow_wave(diags):
+    print("Validating Slow Wave Test...")
+    return validate_sound_wave(diags)
 
 
 def ensure_flekspy_installed():
@@ -730,7 +815,11 @@ def main():
         "charge_exchange": validate_exosphere_charge_exchange,
         "exosphere": validate_exosphere,
         "chamber": validate_chamber,
-        "beam": validate_beam
+        "beam": validate_beam,
+        "sound_wave": validate_sound_wave,
+        "fast_wave": validate_fast_wave,
+        "alfven_wave": validate_alfven_wave,
+        "slow_wave": validate_slow_wave
     }
     
     # Discover test subdirectories under tests/test_standalone
@@ -739,6 +828,11 @@ def main():
     # Iterate through sorted subdirectories
     subdirs = sorted([d for d in os.listdir(test_standalone_dir) 
                       if os.path.isdir(os.path.join(test_standalone_dir, d)) and d not in ["performance"]])
+    
+    # Filter by command-line arguments if provided
+    targets = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
+    if targets:
+        subdirs = [d for d in subdirs if d in targets]
     
     tests = []
     for d in subdirs:
@@ -755,6 +849,7 @@ def main():
     results = [] # Collect results for summary table
     
     for test_dir, name, validator in tests:
+        val_res = False
         print(f"\n==========================================")
         print(f"Starting test: {name.upper()}")
         print(f"==========================================")
@@ -808,8 +903,11 @@ def main():
 
         finally:
             # Always clean up run output after each test to keep disk usage low.
-            print(f"  Cleaning up run_test/ output for {name.upper()}...")
-            cleanup_run_dir()
+            if val_res:
+                print(f"  Cleaning up run_test/ output for {name.upper()}...")
+                cleanup_run_dir()
+            else:
+                print(f"  Skipping cleanup for {name.upper()} to preserve diagnostics.")
 
 
     # ----------------------------------------------------


### PR DESCRIPTION
This is a WIP PR for adding all kinds of wave tests for standalone FLEKS. It is not fully working.

These wave tests are based on the linearized MHD waves in the setup: https://henry2004y.github.io/KeyNotes/contents/test.html#wave-tests

I have checked the fast wave test and came up with a BATSRUS test. It looks correct with an amplitude of 1e-6. However, the hopefully identical setup in FLEKS does not turn to an expected solution. There are several possibilities:
1. The initialization is wrong. Somehow there are errors in the conversion from MHD quantities to full-PIC quantities.
2. The PIC noise level is so that such that it destroys the wave pattern. This is less likely to be the main culprit though.