### PR TITLE
Refactor the exosphere implementation

### DIFF
--- a/include/ExosphereSource.h
+++ b/include/ExosphereSource.h
@@ -1,0 +1,281 @@
+#ifndef _EXOSPHERESOURCE_H_
+#define _EXOSPHERESOURCE_H_
+
+#include "SourceInterface.h"
+#include "Particles.h"
+
+class ExosphereSource : public SourceInterface {
+private:
+  std::vector<ExosphereInfo> exoParams;
+  TestCase testCase = RegularSimulation;
+  double pickup_xMin = -1.0;
+  double pickup_xMax = 1.0;
+
+public:
+  ExosphereSource(const FluidInterface& other, int id, std::string tag,
+                  FluidType typeIn = SourceFluid)
+      : SourceInterface(other, id, tag, typeIn) {
+    info = "Exosphere Photoionization Source Class";
+  }
+
+  void add_exosphere_params(const std::vector<ExosphereInfo>& infos) {
+    exoParams = infos;
+  }
+
+  void set_pickup_params(TestCase tCase, double xMin, double xMax) {
+    testCase = tCase;
+    pickup_xMin = xMin;
+    pickup_xMax = xMax;
+  }
+
+  void post_regrid() override {
+    distribute_arrays();
+    set_source_standalone();
+  }
+
+  void set_source(const FluidInterface& other) override {
+    set_node_fluid(other);
+    set_source_standalone();
+  }
+
+  void set_source_standalone() {
+    amrex::Print() << "ExosphereSource::set_source_standalone() is called!" << std::endl;
+
+    // 1. Find electron species if any
+    int iElec = -1;
+    for (int i = 0; i < nFluid; ++i) {
+      if (QoQi_S[i] < 0.0) {
+        iElec = i;
+        break;
+      }
+    }
+
+    // 2. Initialize all nodeFluid rates to 0
+    for (int iLev = 0; iLev < n_lev(); iLev++) {
+      if (nodeFluid[iLev].empty()) continue;
+      nodeFluid[iLev].setVal(0.0);
+    }
+
+    // 3. Write un-normalized analytical density and pressure shapes to nodes
+    for (int iLev = 0; iLev < n_lev(); iLev++) {
+      if (nodeFluid[iLev].empty()) continue;
+
+      const amrex::Real* dx = Geom(iLev).CellSize();
+      const auto plo = Geom(iLev).ProbLo();
+      const amrex::Box gbx = convert(Geom(0).Domain(), { AMREX_D_DECL(1, 1, 1) });
+
+      for (amrex::MFIter mfi(nodeFluid[iLev]); mfi.isValid(); ++mfi) {
+        const amrex::Box& box = mfi.fabbox();
+        const auto lo = lbound(box);
+        const auto hi = ubound(box);
+        const amrex::Array4<amrex::Real>& arr = nodeFluid[iLev][mfi].array();
+
+        for (int k = lo.z; k <= hi.z; ++k) {
+          for (int j = lo.y; j <= hi.y; ++j) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+              
+              amrex::IntVect idx = { AMREX_D_DECL(i, j, k) };
+              for (int iDim = 0; iDim < nDim; iDim++) {
+                if (Geom(iLev).isPeriodic(iDim)) {
+                  idx[iDim] = shift_periodic_index(
+                      idx[iDim], gbx.smallEnd(iDim), gbx.bigEnd(iDim));
+                }
+              }
+
+              // Calculate node position in PIC units
+              double xyz[3] = { 0, 0, 0 };
+              for (int iDim = 0; iDim < get_fluid_dimension(); iDim++) {
+                xyz[iDim] = (idx[iDim] * dx[iDim] + plo[iDim]);
+              }
+
+              // Compute contribution from each species profile
+              for (size_t iInfo = 0; iInfo < exoParams.size(); ++iInfo) {
+                const auto& param = exoParams[iInfo];
+                int iSp = param.iSpecies - 1;
+                if (iSp < 0 || iSp >= nFluid) continue;
+
+                double r = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1] + xyz[2]*xyz[2]);
+                if (r < param.exobaseRadius) continue;
+
+                if (testCase == Pickup && (xyz[0] < pickup_xMin || xyz[0] > pickup_xMax)) continue;
+
+                if (param.shadowRadius > 0 && xyz[0] < 0) {
+                  double perp2 = xyz[1]*xyz[1] + (get_fluid_dimension() > 2 ? xyz[2]*xyz[2] : 0.0);
+                  if (perp2 < param.shadowRadius * param.shadowRadius) continue;
+                }
+
+                double dens = 0.0;
+                int n0_size = param.n0.size();
+                if (param.neutralProfile == "exponential") {
+                  for (int idx_p = 0; idx_p < n0_size; idx_p++) {
+                    dens += param.n0[idx_p] * exp(-(r - param.r0) / param.H0[idx_p]);
+                  }
+                } else if (param.neutralProfile == "power-law" || param.neutralProfile == "PowerLaw") {
+                  for (int idx_p = 0; idx_p < n0_size; idx_p++) {
+                    dens += param.n0[idx_p] * pow(param.r0 / r, param.k0[idx_p]);
+                  }
+                } else if (param.neutralProfile == "ChamberlainH") {
+                  for (int idx_p = 0; idx_p < n0_size; idx_p++) {
+                    dens += param.n0[idx_p] * exp(-param.H0[idx_p] * (1.0 / param.r0 - 1.0 / r));
+                  }
+                }
+
+                arr(i, j, k, iRho_I[iSp]) += dens;
+                
+                double T0_K = param.T0.empty() ? 0.0 : param.T0[0];
+                double mass_kg = MoMi_S[iSp] * get_No2SiM();
+                double uth_SI = (T0_K > 0 && mass_kg > 0) ? sqrt(cBoltzmannSI * T0_K / mass_kg) : 0.0;
+                double uth = uth_SI * get_Si2NoV();
+                
+                arr(i, j, k, iP_I[iSp]) += dens * uth * uth;
+                if (useMhdPe) {
+                  arr(i, j, k, iPe) += dens * uth * uth * 1e-2;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // 4. Compute exact cell-center interpolated global volume integrals
+    std::vector<double> sumGlobal(exoParams.size(), 0.0);
+    for (size_t iInfo = 0; iInfo < exoParams.size(); ++iInfo) {
+      int iSp = exoParams[iInfo].iSpecies - 1;
+      if (iSp < 0 || iSp >= nFluid) continue;
+
+      double sumLocal = 0.0;
+      for (int iLev = 0; iLev < n_lev(); iLev++) {
+        if (nodeFluid[iLev].empty()) continue;
+
+        const amrex::Real* dx = Geom(iLev).CellSize();
+        const double vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+
+        for (amrex::MFIter mfi(nodeFluid[iLev]); mfi.isValid(); ++mfi) {
+          amrex::Box cell_box = mfi.validbox();
+          cell_box.convert(amrex::IndexType::TheCellType());
+
+          const auto lo = lbound(cell_box);
+          const auto hi = ubound(cell_box);
+          const amrex::Array4<amrex::Real>& arr = nodeFluid[iLev][mfi].array();
+
+          for (int k = lo.z; k <= hi.z; ++k) {
+            for (int j = lo.y; j <= hi.y; ++j) {
+              for (int i = lo.x; i <= hi.x; ++i) {
+                // Direct trilinear/bilinear node average to cell center to match evaluation exactly
+                double sum_node = 0.0;
+                int i_max = i + 1;
+                int j_max = (get_fluid_dimension() > 1) ? j + 1 : j;
+                int k_max = (get_fluid_dimension() > 2) ? k + 1 : k;
+
+                for (int nk = k; nk <= k_max; nk++) {
+                  for (int nj = j; nj <= j_max; nj++) {
+                    for (int ni = i; ni <= i_max; ni++) {
+                      sum_node += arr(ni, nj, nk, iRho_I[iSp]);
+                    }
+                  }
+                }
+                
+                int n_corners = (i_max - i + 1) * (j_max - j + 1) * (k_max - k + 1);
+                double dens = sum_node / n_corners;
+                sumLocal += dens * vol;
+              }
+            }
+          }
+        }
+      }
+
+      sumGlobal[iInfo] = sumLocal;
+      amrex::ParallelDescriptor::ReduceRealSum(sumGlobal[iInfo]);
+    }
+
+    // 5. Scale components by norm_factor
+    for (size_t iInfo = 0; iInfo < exoParams.size(); ++iInfo) {
+      int iSp = exoParams[iInfo].iSpecies - 1;
+      if (iSp < 0 || iSp >= nFluid) continue;
+
+      if (sumGlobal[iInfo] > 0.0) {
+        double norm_factor = (exoParams[iInfo].totalProductionRate / sumGlobal[iInfo])
+                             * (MoMi_S[iSp] / get_Si2NoT());
+
+        amrex::Print() << "  Species Info " << iInfo 
+                       << ": sumGlobal = " << sumGlobal[iInfo] 
+                       << ", norm_factor = " << norm_factor << std::endl;
+
+        for (int iLev = 0; iLev < n_lev(); iLev++) {
+          if (nodeFluid[iLev].empty()) continue;
+          nodeFluid[iLev].mult(norm_factor, iRho_I[iSp], 1, 0);
+          nodeFluid[iLev].mult(norm_factor, iP_I[iSp], 1, 0);
+          if (useMhdPe) {
+            nodeFluid[iLev].mult(norm_factor, iPe, 1, 0);
+          }
+        }
+      }
+    }
+
+    // 6. Compute neutralizing electron rates for charge neutrality
+    if (iElec >= 0) {
+      for (int iLev = 0; iLev < n_lev(); iLev++) {
+        if (nodeFluid[iLev].empty()) continue;
+
+        for (amrex::MFIter mfi(nodeFluid[iLev]); mfi.isValid(); ++mfi) {
+          const amrex::Box& box = mfi.fabbox();
+          const auto lo = amrex::lbound(box);
+          const auto hi = amrex::ubound(box);
+          const amrex::Array4<amrex::Real>& arr = nodeFluid[iLev][mfi].array();
+
+          for (int k = lo.z; k <= hi.z; ++k) {
+            for (int j = lo.y; j <= hi.y; ++j) {
+              for (int i = lo.x; i <= hi.x; ++i) {
+                double sum_num_dens = 0.0;
+                for (int iSp = 0; iSp < nFluid; iSp++) {
+                  if (iSp != iElec) {
+                    sum_num_dens += arr(i, j, k, iRho_I[iSp]) / MoMi_S[iSp];
+                  }
+                }
+                arr(i, j, k, iRho_I[iElec]) = sum_num_dens * MoMi_S[iElec];
+
+                double sum_p = 0.0;
+                for (int iSp = 0; iSp < nFluid; iSp++) {
+                  if (iSp != iElec) {
+                    double T0_K = 0.0;
+                    for (size_t iInfo = 0; iInfo < exoParams.size(); ++iInfo) {
+                      if (exoParams[iInfo].iSpecies - 1 == iSp) {
+                        T0_K = exoParams[iInfo].T0.empty() ? 0.0 : exoParams[iInfo].T0[0];
+                        break;
+                      }
+                    }
+                    double mass_kg = MoMi_S[iElec] * get_No2SiM();
+                    double uth_SI = (T0_K > 0 && mass_kg > 0) ? sqrt(cBoltzmannSI * T0_K / mass_kg) : 0.0;
+                    double uth = uth_SI * get_Si2NoV();
+                    sum_p += (arr(i, j, k, iRho_I[iSp]) / MoMi_S[iSp]) * MoMi_S[iElec] * uth * uth;
+                  }
+                }
+                arr(i, j, k, iP_I[iElec]) = sum_p;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (!isGridEmpty && useCurrent) {
+      for (int iLev = 0; iLev < n_lev(); iLev++) {
+        amrex::MultiFab currentMF(nodeFluid[iLev], amrex::make_alias, iJx, 3);
+        currentMF.setVal(0, currentMF.nGrow());
+      }
+    }
+
+    for (int iSp = 0; iSp < nFluid; iSp++) {
+      double sumVal = 0.0;
+      for (int iLev = 0; iLev < n_lev(); ++iLev) {
+        if (!nodeFluid[iLev].empty()) {
+          sumVal += nodeFluid[iLev].sum(iRho_I[iSp]);
+        }
+      }
+      amrex::Print() << "  Species " << iSp << " nodeFluid mass rate sum = " << sumVal << std::endl;
+    }
+  }
+};
+
+#endif

--- a/include/ExosphereSource.h
+++ b/include/ExosphereSource.h
@@ -1,8 +1,8 @@
 #ifndef _EXOSPHERESOURCE_H_
 #define _EXOSPHERESOURCE_H_
 
-#include "SourceInterface.h"
 #include "Particles.h"
+#include "SourceInterface.h"
 
 class ExosphereSource : public SourceInterface {
 private:
@@ -39,7 +39,8 @@ public:
   }
 
   void set_source_standalone() {
-    amrex::Print() << "ExosphereSource::set_source_standalone() is called!" << std::endl;
+    amrex::Print() << "ExosphereSource::set_source_standalone() is called!"
+                   << std::endl;
 
     // 1. Find electron species if any
     int iElec = -1;
@@ -52,17 +53,20 @@ public:
 
     // 2. Initialize all nodeFluid rates to 0
     for (int iLev = 0; iLev < n_lev(); iLev++) {
-      if (nodeFluid[iLev].empty()) continue;
+      if (nodeFluid[iLev].empty())
+        continue;
       nodeFluid[iLev].setVal(0.0);
     }
 
     // 3. Write un-normalized analytical density and pressure shapes to nodes
     for (int iLev = 0; iLev < n_lev(); iLev++) {
-      if (nodeFluid[iLev].empty()) continue;
+      if (nodeFluid[iLev].empty())
+        continue;
 
       const amrex::Real* dx = Geom(iLev).CellSize();
       const auto plo = Geom(iLev).ProbLo();
-      const amrex::Box gbx = convert(Geom(0).Domain(), { AMREX_D_DECL(1, 1, 1) });
+      const amrex::Box gbx =
+          convert(Geom(0).Domain(), { AMREX_D_DECL(1, 1, 1) });
 
       for (amrex::MFIter mfi(nodeFluid[iLev]); mfi.isValid(); ++mfi) {
         const amrex::Box& box = mfi.fabbox();
@@ -73,7 +77,7 @@ public:
         for (int k = lo.z; k <= hi.z; ++k) {
           for (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {
-              
+
               amrex::IntVect idx = { AMREX_D_DECL(i, j, k) };
               for (int iDim = 0; iDim < nDim; iDim++) {
                 if (Geom(iLev).isPeriodic(iDim)) {
@@ -92,41 +96,55 @@ public:
               for (size_t iInfo = 0; iInfo < exoParams.size(); ++iInfo) {
                 const auto& param = exoParams[iInfo];
                 int iSp = param.iSpecies - 1;
-                if (iSp < 0 || iSp >= nFluid) continue;
+                if (iSp < 0 || iSp >= nFluid)
+                  continue;
 
-                double r = sqrt(xyz[0]*xyz[0] + xyz[1]*xyz[1] + xyz[2]*xyz[2]);
-                if (r < param.exobaseRadius) continue;
+                double r =
+                    sqrt(xyz[0] * xyz[0] + xyz[1] * xyz[1] + xyz[2] * xyz[2]);
+                if (r < param.exobaseRadius)
+                  continue;
 
-                if (testCase == Pickup && (xyz[0] < pickup_xMin || xyz[0] > pickup_xMax)) continue;
+                if (testCase == Pickup &&
+                    (xyz[0] < pickup_xMin || xyz[0] > pickup_xMax))
+                  continue;
 
                 if (param.shadowRadius > 0 && xyz[0] < 0) {
-                  double perp2 = xyz[1]*xyz[1] + (get_fluid_dimension() > 2 ? xyz[2]*xyz[2] : 0.0);
-                  if (perp2 < param.shadowRadius * param.shadowRadius) continue;
+                  double perp2 =
+                      xyz[1] * xyz[1] +
+                      (get_fluid_dimension() > 2 ? xyz[2] * xyz[2] : 0.0);
+                  if (perp2 < param.shadowRadius * param.shadowRadius)
+                    continue;
                 }
 
                 double dens = 0.0;
                 int n0_size = param.n0.size();
                 if (param.neutralProfile == "exponential") {
                   for (int idx_p = 0; idx_p < n0_size; idx_p++) {
-                    dens += param.n0[idx_p] * exp(-(r - param.r0) / param.H0[idx_p]);
+                    dens += param.n0[idx_p] *
+                            exp(-(r - param.r0) / param.H0[idx_p]);
                   }
-                } else if (param.neutralProfile == "power-law" || param.neutralProfile == "PowerLaw") {
+                } else if (param.neutralProfile == "power-law" ||
+                           param.neutralProfile == "PowerLaw") {
                   for (int idx_p = 0; idx_p < n0_size; idx_p++) {
-                    dens += param.n0[idx_p] * pow(param.r0 / r, param.k0[idx_p]);
+                    dens +=
+                        param.n0[idx_p] * pow(param.r0 / r, param.k0[idx_p]);
                   }
                 } else if (param.neutralProfile == "ChamberlainH") {
                   for (int idx_p = 0; idx_p < n0_size; idx_p++) {
-                    dens += param.n0[idx_p] * exp(-param.H0[idx_p] * (1.0 / param.r0 - 1.0 / r));
+                    dens += param.n0[idx_p] *
+                            exp(-param.H0[idx_p] * (1.0 / param.r0 - 1.0 / r));
                   }
                 }
 
                 arr(i, j, k, iRho_I[iSp]) += dens;
-                
+
                 double T0_K = param.T0.empty() ? 0.0 : param.T0[0];
                 double mass_kg = MoMi_S[iSp] * get_No2SiM();
-                double uth_SI = (T0_K > 0 && mass_kg > 0) ? sqrt(cBoltzmannSI * T0_K / mass_kg) : 0.0;
+                double uth_SI = (T0_K > 0 && mass_kg > 0)
+                                    ? sqrt(cBoltzmannSI * T0_K / mass_kg)
+                                    : 0.0;
                 double uth = uth_SI * get_Si2NoV();
-                
+
                 arr(i, j, k, iP_I[iSp]) += dens * uth * uth;
                 if (useMhdPe) {
                   arr(i, j, k, iPe) += dens * uth * uth * 1e-2;
@@ -142,11 +160,13 @@ public:
     std::vector<double> sumGlobal(exoParams.size(), 0.0);
     for (size_t iInfo = 0; iInfo < exoParams.size(); ++iInfo) {
       int iSp = exoParams[iInfo].iSpecies - 1;
-      if (iSp < 0 || iSp >= nFluid) continue;
+      if (iSp < 0 || iSp >= nFluid)
+        continue;
 
       double sumLocal = 0.0;
       for (int iLev = 0; iLev < n_lev(); iLev++) {
-        if (nodeFluid[iLev].empty()) continue;
+        if (nodeFluid[iLev].empty())
+          continue;
 
         const amrex::Real* dx = Geom(iLev).CellSize();
         const double vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
@@ -162,7 +182,8 @@ public:
           for (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
               for (int i = lo.x; i <= hi.x; ++i) {
-                // Direct trilinear/bilinear node average to cell center to match evaluation exactly
+                // Direct trilinear/bilinear node average to cell center to
+                // match evaluation exactly
                 double sum_node = 0.0;
                 int i_max = i + 1;
                 int j_max = (get_fluid_dimension() > 1) ? j + 1 : j;
@@ -175,8 +196,9 @@ public:
                     }
                   }
                 }
-                
-                int n_corners = (i_max - i + 1) * (j_max - j + 1) * (k_max - k + 1);
+
+                int n_corners =
+                    (i_max - i + 1) * (j_max - j + 1) * (k_max - k + 1);
                 double dens = sum_node / n_corners;
                 sumLocal += dens * vol;
               }
@@ -192,18 +214,21 @@ public:
     // 5. Scale components by norm_factor
     for (size_t iInfo = 0; iInfo < exoParams.size(); ++iInfo) {
       int iSp = exoParams[iInfo].iSpecies - 1;
-      if (iSp < 0 || iSp >= nFluid) continue;
+      if (iSp < 0 || iSp >= nFluid)
+        continue;
 
       if (sumGlobal[iInfo] > 0.0) {
-        double norm_factor = (exoParams[iInfo].totalProductionRate / sumGlobal[iInfo])
-                             * (MoMi_S[iSp] / get_Si2NoT());
+        double norm_factor =
+            (exoParams[iInfo].totalProductionRate / sumGlobal[iInfo]) *
+            (MoMi_S[iSp] / get_Si2NoT());
 
-        amrex::Print() << "  Species Info " << iInfo 
-                       << ": sumGlobal = " << sumGlobal[iInfo] 
+        amrex::Print() << "  Species Info " << iInfo
+                       << ": sumGlobal = " << sumGlobal[iInfo]
                        << ", norm_factor = " << norm_factor << std::endl;
 
         for (int iLev = 0; iLev < n_lev(); iLev++) {
-          if (nodeFluid[iLev].empty()) continue;
+          if (nodeFluid[iLev].empty())
+            continue;
           nodeFluid[iLev].mult(norm_factor, iRho_I[iSp], 1, 0);
           nodeFluid[iLev].mult(norm_factor, iP_I[iSp], 1, 0);
           if (useMhdPe) {
@@ -216,7 +241,8 @@ public:
     // 6. Compute neutralizing electron rates for charge neutrality
     if (iElec >= 0) {
       for (int iLev = 0; iLev < n_lev(); iLev++) {
-        if (nodeFluid[iLev].empty()) continue;
+        if (nodeFluid[iLev].empty())
+          continue;
 
         for (amrex::MFIter mfi(nodeFluid[iLev]); mfi.isValid(); ++mfi) {
           const amrex::Box& box = mfi.fabbox();
@@ -241,14 +267,19 @@ public:
                     double T0_K = 0.0;
                     for (size_t iInfo = 0; iInfo < exoParams.size(); ++iInfo) {
                       if (exoParams[iInfo].iSpecies - 1 == iSp) {
-                        T0_K = exoParams[iInfo].T0.empty() ? 0.0 : exoParams[iInfo].T0[0];
+                        T0_K = exoParams[iInfo].T0.empty()
+                                   ? 0.0
+                                   : exoParams[iInfo].T0[0];
                         break;
                       }
                     }
                     double mass_kg = MoMi_S[iElec] * get_No2SiM();
-                    double uth_SI = (T0_K > 0 && mass_kg > 0) ? sqrt(cBoltzmannSI * T0_K / mass_kg) : 0.0;
+                    double uth_SI = (T0_K > 0 && mass_kg > 0)
+                                        ? sqrt(cBoltzmannSI * T0_K / mass_kg)
+                                        : 0.0;
                     double uth = uth_SI * get_Si2NoV();
-                    sum_p += (arr(i, j, k, iRho_I[iSp]) / MoMi_S[iSp]) * MoMi_S[iElec] * uth * uth;
+                    sum_p += (arr(i, j, k, iRho_I[iSp]) / MoMi_S[iSp]) *
+                             MoMi_S[iElec] * uth * uth;
                   }
                 }
                 arr(i, j, k, iP_I[iElec]) = sum_p;
@@ -273,7 +304,8 @@ public:
           sumVal += nodeFluid[iLev].sum(iRho_I[iSp]);
         }
       }
-      amrex::Print() << "  Species " << iSp << " nodeFluid mass rate sum = " << sumVal << std::endl;
+      amrex::Print() << "  Species " << iSp
+                     << " nodeFluid mass rate sum = " << sumVal << std::endl;
     }
   }
 };

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -326,11 +326,6 @@ public:
                             const bool doSelectRegion = false,
                             const bool adaptivePPC = false);
 
-  void add_particles_exosphere(
-      const amrex::MultiFab& exoDensity, amrex::Real dt, int iLev,
-      amrex::Real weightMacro, int iComp, amrex::Real uth = 0.0,
-      Particles<NStructReal, NStructInt>* electronParts = nullptr,
-      amrex::Real uth_elec = 0.0);
 
   // Copy particles from (ip,jp,kp) to (ig, jg, kg) and shift boundary
   // particle's coordinates accordingly.

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -326,7 +326,6 @@ public:
                             const bool doSelectRegion = false,
                             const bool adaptivePPC = false);
 
-
   // Copy particles from (ip,jp,kp) to (ig, jg, kg) and shift boundary
   // particle's coordinates accordingly.
   void outflow_bc(const amrex::MFIter& mfi, const amrex::IntVect ijkGst,

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -18,7 +18,31 @@
 #include "TimeCtr.h"
 #include "UMultiFab.h"
 
+#include <cmath>
+
 enum class CrossSection { LS = 0, MT };
+
+inline amrex::Real calculate_charge_exchange_cross_section(
+    amrex::Real v_rel_SI, amrex::Real mass_ion_amu, CrossSection cs) {
+  if (v_rel_SI <= 0.0)
+    return 0.0;
+
+  amrex::Real sigma = 0.0;
+  if (cs == CrossSection::LS) {
+    amrex::Real erel = 0.5 * (mass_ion_amu * cProtonMassSI) * (v_rel_SI * v_rel_SI) *
+                       6.2415e15; // relative energy in keV
+    if (erel <= 0.0)
+      return 0.0;
+    sigma = (4.15 - 0.531 * std::log(erel)) * (4.15 - 0.531 * std::log(erel)) *
+            std::pow(1.0 - std::exp(-67.3 / erel), 4.5) *
+            1e-20; // cross section in m^2
+  } else if (cs == CrossSection::MT) {
+    amrex::Real dvcm = v_rel_SI * 1e2; // velocity in cm/s
+    sigma = std::pow(1.6 - 0.0695 * std::log(dvcm), 2) * 1e-18; // cross section in m^2
+  }
+  return sigma;
+}
+
 
 enum class PartMode { PIC = 0, Neutral, SEP };
 

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -29,7 +29,8 @@ inline amrex::Real calculate_charge_exchange_cross_section(
 
   amrex::Real sigma = 0.0;
   if (cs == CrossSection::LS) {
-    amrex::Real erel = 0.5 * (mass_ion_amu * cProtonMassSI) * (v_rel_SI * v_rel_SI) *
+    amrex::Real erel = 0.5 * (mass_ion_amu * cProtonMassSI) *
+                       (v_rel_SI * v_rel_SI) *
                        6.2415e15; // relative energy in keV
     if (erel <= 0.0)
       return 0.0;
@@ -38,11 +39,11 @@ inline amrex::Real calculate_charge_exchange_cross_section(
             1e-20; // cross section in m^2
   } else if (cs == CrossSection::MT) {
     amrex::Real dvcm = v_rel_SI * 1e2; // velocity in cm/s
-    sigma = std::pow(1.6 - 0.0695 * std::log(dvcm), 2) * 1e-18; // cross section in m^2
+    sigma = std::pow(1.6 - 0.0695 * std::log(dvcm), 2) *
+            1e-18; // cross section in m^2
   }
   return sigma;
 }
-
 
 enum class PartMode { PIC = 0, Neutral, SEP };
 

--- a/include/Pic.h
+++ b/include/Pic.h
@@ -220,7 +220,6 @@ public:
     centerMM.resize(n_lev_max());
 
     jHat.resize(n_lev_max());
-    exoDensity.resize(n_lev_max());
 
     // At most 10 species.
     pBCs.resize(10);
@@ -246,6 +245,12 @@ public:
   bool has_particles() const { return !parts.empty(); }
   const amrex::Vector<amrex::MultiFab> &get_nodeB() const { return nodeB; }
 
+  bool get_useExosphere() const { return useExosphere; }
+  const std::vector<ExosphereInfo>& get_exoInfos() const { return exoInfos; }
+  TestCase get_testCase() const { return testCase; }
+  amrex::Real get_pickup_xMin() const { return pickup_xMin; }
+  amrex::Real get_pickup_xMax() const { return pickup_xMax; }
+
   void set_stateOH(OHInterface *in) { stateOH = in; }
   void set_sourceOH(OHInterface *in) { sourcePT2OH = in; }
   void set_fluid_source(SourceInterface *in) { source = in; }
@@ -267,8 +272,6 @@ public:
   void fill_new_center_B();
 
   void fill_particles();
-
-  void init_exosphere();
 
   void init_source(const FluidInterface &interfaceIn) {
     // To be implemented
@@ -614,7 +617,6 @@ private:
 
   std::vector<ExosphereInfo> exoInfos;
   bool useExosphere = false;
-  amrex::Vector<amrex::MultiFab> exoDensity;
 
   bool doElectronImpactIonization = false;
   amrex::Real ionizationThresholdEnergy = 13.6;

--- a/include/Pic.h
+++ b/include/Pic.h
@@ -246,7 +246,7 @@ public:
   const amrex::Vector<amrex::MultiFab> &get_nodeB() const { return nodeB; }
 
   bool get_useExosphere() const { return useExosphere; }
-  const std::vector<ExosphereInfo>& get_exoInfos() const { return exoInfos; }
+  const std::vector<ExosphereInfo> &get_exoInfos() const { return exoInfos; }
   TestCase get_testCase() const { return testCase; }
   amrex::Real get_pickup_xMin() const { return pickup_xMin; }
   amrex::Real get_pickup_xMax() const { return pickup_xMax; }

--- a/include/Pic.h
+++ b/include/Pic.h
@@ -278,7 +278,7 @@ public:
 
   //----------------Initialization end-------------------------------
 
-  void charge_exchange();
+  void coupling_charge_exchange();
   void electron_impact_ionization();
   void exosphere_charge_exchange();
 

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -7,6 +7,7 @@
 #include "UserSource.h"
 #endif
 #include "Shape.h"
+#include "ExosphereSource.h"
 
 using namespace amrex;
 
@@ -88,7 +89,14 @@ void Domain::init(double time, const int iDomain,
   pic->set_sourceOH(sourcePT2OH.get());
 #endif
 
-  if (useFluidSource || useSource) {
+  if (pic->get_useExosphere()) {
+    auto exoSource =
+        std::make_unique<ExosphereSource>(*fi, gridID, "picSource", SourceFluid);
+    exoSource->add_exosphere_params(pic->get_exoInfos());
+    exoSource->set_pickup_params(pic->get_testCase(), pic->get_pickup_xMin(), pic->get_pickup_xMax());
+    source = std::move(exoSource);
+    amrex::Print() << source->get_info() << " is used for source" << std::endl;
+  } else if (useFluidSource || useSource) {
     source =
         std::make_unique<UserSource>(*fi, gridID, "picSource", SourceFluid);
     amrex::Print() << source->get_info() << " is used for source" << std::endl;
@@ -132,6 +140,8 @@ void Domain::init(double time, const int iDomain,
       stateOH->regrid(fi->boxArray(0), fi.get());
     if (sourcePT2OH)
       sourcePT2OH->regrid(fi->boxArray(0), fi.get());
+    if (source)
+      source->regrid(fi->boxArray(0), fi.get());
 
     if (doRestart && doRestartFIOnly) {
       pic->regrid(fi->boxArray(0), fi.get());

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -6,8 +6,8 @@
 #else
 #include "UserSource.h"
 #endif
-#include "Shape.h"
 #include "ExosphereSource.h"
+#include "Shape.h"
 
 using namespace amrex;
 
@@ -90,10 +90,11 @@ void Domain::init(double time, const int iDomain,
 #endif
 
   if (pic->get_useExosphere()) {
-    auto exoSource =
-        std::make_unique<ExosphereSource>(*fi, gridID, "picSource", SourceFluid);
+    auto exoSource = std::make_unique<ExosphereSource>(*fi, gridID, "picSource",
+                                                       SourceFluid);
     exoSource->add_exosphere_params(pic->get_exoInfos());
-    exoSource->set_pickup_params(pic->get_testCase(), pic->get_pickup_xMin(), pic->get_pickup_xMax());
+    exoSource->set_pickup_params(pic->get_testCase(), pic->get_pickup_xMin(),
+                                 pic->get_pickup_xMax());
     source = std::move(exoSource);
     amrex::Print() << source->get_info() << " is used for source" << std::endl;
   } else if (useFluidSource || useSource) {

--- a/src/Particles.cpp
+++ b/src/Particles.cpp
@@ -3595,16 +3595,7 @@ Real Particles<NStructReal, NStructInt>::charge_exchange_dis(Real* vp, Real* vh,
 
   dv = sqrt(dv2);
 
-  Real erel = 0.5 * 1.674E-27 * dv2 * 6.2415E15; // in keV
-
-  Real sigma = 0;
-  if (cs == CrossSection::LS) {
-    sigma = (4.15 - 0.531 * log(erel)) * (4.15 - 0.531 * log(erel)) *
-            pow(1 - exp(-67.3 / erel), 4.5) * 1E-20; // cross section in m^2
-  } else if (cs == CrossSection::MT) {
-    Real dvcm = dv * 1E2;                             // velocity in cm/s
-    sigma = pow(1.6 - 0.0695 * log(dvcm), 2) * 1e-18; // cross section in m^2
-  }
+  Real sigma = calculate_charge_exchange_cross_section(dv, 1.0, cs);
 
   Real dvpup2 = 0;
   for (int i = 0; i < 3; ++i) {
@@ -3712,6 +3703,9 @@ void Particles<NStructReal, NStructInt>::charge_exchange(
   std::string nameFunc = "Pts::charge_exchange";
 
   timing_func(nameFunc);
+
+  if (!is_neutral())
+    return;
 
   if (dt <= 0)
     return;

--- a/src/Particles.cpp
+++ b/src/Particles.cpp
@@ -151,8 +151,11 @@ void Particles<NStructReal, NStructInt>::add_particles_cell(
     nPPC = ppc;
   }
 
-  if (nPPC == 0)
-    return;
+  if (nPPC == 0) {
+    for (int iDim = 0; iDim < nDim; iDim++) {
+      nPPC[iDim] = 2;
+    }
+  }
 
   if (isTargetPPCDefined && !isFake2D) {
     const auto tppc = target_PPC(iLev)[mfi].array();
@@ -364,107 +367,6 @@ void Particles<NStructReal, NStructInt>::add_particles_source(
   }
 }
 
-//==========================================================
-template <int NStructReal, int NStructInt>
-void Particles<NStructReal, NStructInt>::add_particles_exosphere(
-    const amrex::MultiFab& exoDensity, amrex::Real dt, int iLev,
-    amrex::Real weightMacro, int iComp, amrex::Real uth,
-    Particles<NStructReal, NStructInt>* electronParts, amrex::Real uth_elec) {
-  timing_func("Pts::add_particles_exosphere");
-
-  for (MFIter mfi(exoDensity); mfi.isValid(); ++mfi) {
-    const Box& bx = mfi.validbox();
-    const auto& exo_arr = exoDensity[mfi].array();
-
-    const auto lo = lbound(bx);
-    const auto hi = ubound(bx);
-
-    for (int k = lo.z; k <= hi.z; ++k)
-      for (int j = lo.y; j <= hi.y; ++j)
-        for (int i = lo.x; i <= hi.x; ++i) {
-          Real nPhysical = exo_arr(i, j, k, iComp) * dt;
-          if (nPhysical <= 0)
-            continue;
-
-          int nMacro = (int)(nPhysical / weightMacro);
-          if (randNum() < (nPhysical / weightMacro - nMacro))
-            nMacro++;
-
-          if (nMacro > 0) {
-            Real weight = nPhysical / nMacro;
-            Real q = qomSign * weight;
-            ParticleTileType& particles =
-                get_particle_tile(iLev, mfi, { AMREX_D_DECL(i, j, k) });
-
-            Real q_elec = 0.0;
-            ParticleTileType* elec_tile = nullptr;
-            if (electronParts) {
-              q_elec = electronParts->get_qomSign() * weight;
-              elec_tile = &(electronParts->get_particle_tile(
-                  iLev, mfi, { AMREX_D_DECL(i, j, k) }));
-            }
-
-            for (int im = 0; im < nMacro; ++im) {
-              // Sample thermal velocity using Box-Muller transform for ion
-              Real u = 0, v = 0, w = 0;
-              if (uth > 0) {
-                Real prob1 = sqrt(-2.0 * log(1.0 - 0.999999 * randNum()));
-                Real theta1 = 2.0 * M_PI * randNum();
-                Real prob2 = sqrt(-2.0 * log(1.0 - 0.999999 * randNum()));
-                Real theta2 = 2.0 * M_PI * randNum();
-                u = uth * prob1 * cos(theta1);
-                v = uth * prob1 * sin(theta1);
-                w = uth * prob2 * cos(theta2);
-              }
-
-              RealVect xyz;
-              IntVect ijk_coord = { AMREX_D_DECL(i, j, k) };
-              for (int d = 0; d < nDim; ++d) {
-                xyz[d] =
-                    (ijk_coord[d] + randNum()) * dx[iLev][d] + plo[iLev][d];
-              }
-
-              // Spawn Ion
-              ParticleType p;
-              set_ids(p);
-              for (int d = 0; d < nDim; ++d)
-                p.pos(d) = xyz[d];
-              p.rdata(iup_) = u;
-              p.rdata(ivp_) = v;
-              p.rdata(iwp_) = w;
-              p.rdata(iqp_) = q;
-
-              particles.push_back(p);
-
-              // Spawn neutralizing Electron at exact same coordinate and weight
-              if (elec_tile) {
-                Real ue = 0, ve = 0, we = 0;
-                if (uth_elec > 0) {
-                  Real prob1 = sqrt(-2.0 * log(1.0 - 0.999999 * randNum()));
-                  Real theta1 = 2.0 * M_PI * randNum();
-                  Real prob2 = sqrt(-2.0 * log(1.0 - 0.999999 * randNum()));
-                  Real theta2 = 2.0 * M_PI * randNum();
-                  ue = uth_elec * prob1 * cos(theta1);
-                  ve = uth_elec * prob1 * sin(theta1);
-                  we = uth_elec * prob2 * cos(theta2);
-                }
-
-                ParticleType p_elec;
-                electronParts->set_ids(p_elec);
-                for (int d = 0; d < nDim; ++d)
-                  p_elec.pos(d) = xyz[d];
-                p_elec.rdata(iup_) = ue;
-                p_elec.rdata(ivp_) = ve;
-                p_elec.rdata(iwp_) = we;
-                p_elec.rdata(iqp_) = q_elec;
-
-                elec_tile->push_back(p_elec);
-              }
-            }
-          }
-        }
-  }
-}
 
 //==========================================================
 template <int NStructReal, int NStructInt>

--- a/src/Particles.cpp
+++ b/src/Particles.cpp
@@ -365,8 +365,8 @@ void Particles<NStructReal, NStructInt>::add_particles_source(
                 }
               }
 
-              add_particles_cell(iLev, mfi, ijk, interface, false, cell_ppc, Vel(),
-                                 dt);
+              add_particles_cell(iLev, mfi, ijk, interface, false, cell_ppc,
+                                 Vel(), dt);
             }
           }
     }

--- a/src/Particles.cpp
+++ b/src/Particles.cpp
@@ -151,11 +151,8 @@ void Particles<NStructReal, NStructInt>::add_particles_cell(
     nPPC = ppc;
   }
 
-  if (nPPC == 0) {
-    for (int iDim = 0; iDim < nDim; iDim++) {
-      nPPC[iDim] = 2;
-    }
-  }
+  if (nPPC == 0)
+    return;
 
   if (isTargetPPCDefined && !isFake2D) {
     const auto tppc = target_PPC(iLev)[mfi].array();
@@ -334,32 +331,41 @@ void Particles<NStructReal, NStructInt>::add_particles_source(
             }
 #endif
             if (doAdd) {
+              IntVect cell_ppc = ppc;
+              if (cell_ppc == 0 && nPartPerCell == 0) {
+                for (int iDim = 0; iDim < nDim; iDim++) {
+                  cell_ppc[iDim] = 2;
+                }
+              }
+
               if (adaptivePPC) {
-                // Adjust ppc so that the weight of the
+                // Adjust cell_ppc so that the weight of the
                 // source particles is not too small.
                 const int initPPC = product(nPartPerCell);
-                const int sourcePPC = product(ppc);
+                const int sourcePPC = product(cell_ppc);
 
-                Real rho = fi->get_number_density(mfi, ijk, speciesID, iLev);
-                Real rhoSource =
-                    interface->get_number_density(mfi, ijk, speciesID, iLev);
-                if (dt > 0)
-                  rhoSource *= dt;
+                if (initPPC > 0 && sourcePPC > 0) {
+                  Real rho = fi->get_number_density(mfi, ijk, speciesID, iLev);
+                  Real rhoSource =
+                      interface->get_number_density(mfi, ijk, speciesID, iLev);
+                  if (dt > 0)
+                    rhoSource *= dt;
 
-                Real avgInitW = rho / initPPC;
-                Real avgSourceW = rhoSource / sourcePPC;
+                  Real avgInitW = rho / initPPC;
+                  Real avgSourceW = rhoSource / sourcePPC;
 
-                Real targetSourceW = avgInitW * 0.1;
+                  Real targetSourceW = avgInitW * 0.1;
 
-                if (avgSourceW < targetSourceW) {
-                  Real ratio = pow(avgSourceW / targetSourceW, 1.0 / nDim);
-                  for (int iDim = 0; iDim < nDim; iDim++) {
-                    ppc[iDim] = std::max(1, int(ppc[iDim] * ratio));
+                  if (avgSourceW < targetSourceW) {
+                    Real ratio = pow(avgSourceW / targetSourceW, 1.0 / nDim);
+                    for (int iDim = 0; iDim < nDim; iDim++) {
+                      cell_ppc[iDim] = std::max(1, int(cell_ppc[iDim] * ratio));
+                    }
                   }
                 }
               }
 
-              add_particles_cell(iLev, mfi, ijk, interface, false, ppc, Vel(),
+              add_particles_cell(iLev, mfi, ijk, interface, false, cell_ppc, Vel(),
                                  dt);
             }
           }

--- a/src/Particles.cpp
+++ b/src/Particles.cpp
@@ -367,7 +367,6 @@ void Particles<NStructReal, NStructInt>::add_particles_source(
   }
 }
 
-
 //==========================================================
 template <int NStructReal, int NStructInt>
 void Particles<NStructReal, NStructInt>::add_particles_domain() {

--- a/src/Pic.cpp
+++ b/src/Pic.cpp
@@ -1161,8 +1161,6 @@ void Pic::exosphere_charge_exchange() {
     return dens;
   };
 
-
-
   for (int iSp = 0; iSp < nSpecies; ++iSp) {
     if (!parts[iSp] || parts[iSp]->get_charge() <= 0)
       continue; // Exclude electrons and neutral species
@@ -1206,7 +1204,8 @@ void Pic::exosphere_charge_exchange() {
             if (nn <= 0.0)
               continue;
 
-            Real sigma = calculate_charge_exchange_cross_section(v_rel_SI, mass_ion_amu, CrossSection::LS);
+            Real sigma = calculate_charge_exchange_cross_section(
+                v_rel_SI, mass_ion_amu, CrossSection::LS);
             P_j[j] = nn * sigma * v_rel_SI * dt_SI;
             sum_P += P_j[j];
           }

--- a/src/Pic.cpp
+++ b/src/Pic.cpp
@@ -1161,16 +1161,7 @@ void Pic::exosphere_charge_exchange() {
     return dens;
   };
 
-  auto get_cx_cross_section = [&](Real v_rel_SI, Real mass_ion_amu) -> Real {
-    Real erel = 0.5 * (mass_ion_amu * cProtonMassSI) * (v_rel_SI * v_rel_SI) *
-                6.2415e15; // relative energy in keV
-    if (erel <= 0.0)
-      return 0.0;
-    Real sigma = (4.15 - 0.531 * log(erel)) * (4.15 - 0.531 * log(erel)) *
-                 pow(1 - exp(-67.3 / erel), 4.5) *
-                 1e-20; // cross section in m^2
-    return sigma;
-  };
+
 
   for (int iSp = 0; iSp < nSpecies; ++iSp) {
     if (!parts[iSp] || parts[iSp]->get_charge() <= 0)
@@ -1215,7 +1206,7 @@ void Pic::exosphere_charge_exchange() {
             if (nn <= 0.0)
               continue;
 
-            Real sigma = get_cx_cross_section(v_rel_SI, mass_ion_amu);
+            Real sigma = calculate_charge_exchange_cross_section(v_rel_SI, mass_ion_amu, CrossSection::LS);
             P_j[j] = nn * sigma * v_rel_SI * dt_SI;
             sum_P += P_j[j];
           }
@@ -2003,7 +1994,7 @@ void Pic::update(bool doReportIn) {
   // outside the domain have been deleted.
   re_sampling();
 
-  charge_exchange();
+  coupling_charge_exchange();
 
   if (source || useExosphere) {
     fill_source_particles();
@@ -3404,8 +3395,8 @@ void Pic::report_load_balance(bool doReportSummary, bool doReportDetail) {
   }
 }
 
-void Pic::charge_exchange() {
-  timing_func("Pic::charge_exchange");
+void Pic::coupling_charge_exchange() {
+  timing_func("Pic::coupling_charge_exchange");
 
   if (!stateOH || !sourcePT2OH || !source)
     return;

--- a/src/Pic.cpp
+++ b/src/Pic.cpp
@@ -389,8 +389,6 @@ void Pic::distribute_arrays(const Vector<BoxArray>& cGridsOld) {
   distribute_grid_arrays(cGridsOld);
 }
 
-
-
 //==========================================================
 void Pic::pre_regrid() {
   if (!parts.empty()) {

--- a/src/Pic.cpp
+++ b/src/Pic.cpp
@@ -387,146 +387,9 @@ void Pic::distribute_arrays(const Vector<BoxArray>& cGridsOld) {
   }
 
   distribute_grid_arrays(cGridsOld);
-  init_exosphere();
 }
 
-//==========================================================
-Real neutralDensityExponential(Real r, Real r0, const Vector<Real>& n0,
-                               const Vector<Real>& H0) {
-  Real n = 0.0;
-  for (int i = 0; i < n0.size(); i++) {
-    n += n0[i] * exp(-(r - r0) / H0[i]);
-  }
-  return n;
-}
 
-Real neutralDensityPowerLaw(Real r, Real r0, const Vector<Real>& n0,
-                            const Vector<Real>& k0) {
-  Real n = 0.0;
-  for (int i = 0; i < n0.size(); i++) {
-    n += n0[i] * pow(r0 / r, k0[i]);
-  }
-  return n;
-}
-
-Real neutralDensityChamberlainH(Real r, Real r0, const Vector<Real>& n0,
-                                const Vector<Real>& H0) {
-  Real n = 0.0;
-  for (int i = 0; i < n0.size(); i++) {
-    n += n0[i] * exp(-H0[i] * (1.0 / r0 - 1.0 / r));
-  }
-  return n;
-}
-
-void Pic::init_exosphere() {
-  if (exoInfos.empty())
-    return;
-  timing_func("Pic::init_exosphere");
-
-  if (nSpecies <= 0)
-    return;
-
-  exoDensity.resize(n_lev());
-  for (int iLev = 0; iLev < n_lev(); iLev++) {
-    distribute_FabArray(exoDensity[iLev], cGrids[iLev], DistributionMap(iLev),
-                        exoInfos.size(), 0, false);
-  }
-
-  for (size_t iInfo = 0; iInfo < exoInfos.size(); ++iInfo) {
-    auto& info = exoInfos[iInfo];
-    std::string profile = info.neutralProfile;
-    Real r0 = info.r0;
-    Real exobaseRadius = info.exobaseRadius;
-    Real shadowRadius = info.shadowRadius;
-    int n0_size = info.n0.size();
-    const Real* n0_ptr = info.n0.data();
-    const Real* H0_ptr = info.H0.data();
-    const Real* k0_ptr = info.k0.data();
-
-    TestCase tCase = testCase;
-    Real xMin_pickup = pickup_xMin;
-    Real xMax_pickup = pickup_xMax;
-    Real sumLocal = 0;
-    for (int iLev = 0; iLev < n_lev(); iLev++) {
-      const Real* dx = Geom(iLev).CellSize();
-      const Real* plo = Geom(iLev).ProbLo();
-      const Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-
-      Real dx_local[3] = { 0.0, 0.0, 0.0 };
-      Real plo_local[3] = { 0.0, 0.0, 0.0 };
-      for (int d = 0; d < nDim; ++d) {
-        dx_local[d] = dx[d];
-        plo_local[d] = plo[d];
-      }
-
-      for (MFIter mfi(exoDensity[iLev]); mfi.isValid(); ++mfi) {
-        const Box& bx = mfi.validbox();
-        auto const& exo_arr = exoDensity[iLev].array(mfi);
-
-        ParallelFor(bx, [=](int i, int j, int k) {
-          Real pos[3] = { 0.0, 0.0, 0.0 };
-          pos[0] = (i + 0.5) * dx_local[0] + plo_local[0];
-          if (nDim > 1)
-            pos[1] = (j + 0.5) * dx_local[1] + plo_local[1];
-          if (nDim > 2)
-            pos[2] = (k + 0.5) * dx_local[2] + plo_local[2];
-
-          Real r2 = 0;
-          for (int d = 0; d < nDim; ++d) {
-            r2 += pos[d] * pos[d];
-          }
-          Real r = sqrt(r2);
-          Real dens = 0;
-          if (tCase != Pickup ||
-              (pos[0] >= xMin_pickup && pos[0] <= xMax_pickup)) {
-            if (r >= exobaseRadius) {
-              bool inShadow = false;
-              if (shadowRadius > 0) {
-                inShadow = (pos[0] < 0 && (pos[1] * pos[1] +
-                                           (nDim > 2 ? pos[2] * pos[2] : 0)) <
-                                              shadowRadius * shadowRadius);
-              }
-              if (!inShadow) {
-                if (profile == "exponential") {
-                  Real n_val = 0.0;
-                  for (int idx = 0; idx < n0_size; idx++) {
-                    n_val += n0_ptr[idx] * exp(-(r - r0) / H0_ptr[idx]);
-                  }
-                  dens = n_val;
-                } else if (profile == "power-law" || profile == "PowerLaw") {
-                  Real n_val = 0.0;
-                  for (int idx = 0; idx < n0_size; idx++) {
-                    n_val += n0_ptr[idx] * pow(r0 / r, k0_ptr[idx]);
-                  }
-                  dens = n_val;
-                } else if (profile == "ChamberlainH") {
-                  Real n_val = 0.0;
-                  for (int idx = 0; idx < n0_size; idx++) {
-                    n_val +=
-                        n0_ptr[idx] * exp(-H0_ptr[idx] * (1.0 / r0 - 1.0 / r));
-                  }
-                  dens = n_val;
-                }
-              }
-            }
-          }
-          exo_arr(i, j, k, iInfo) = dens * vol;
-        });
-      }
-      sumLocal += exoDensity[iLev].sum(iInfo, true);
-    }
-
-    Real sumGlobal = sumLocal;
-    ParallelDescriptor::ReduceRealSum(sumGlobal);
-
-    if (sumGlobal > 0) {
-      Real norm = info.totalProductionRate / sumGlobal;
-      for (int iLev = 0; iLev < n_lev(); iLev++) {
-        exoDensity[iLev].mult(norm, iInfo, 1, 0);
-      }
-    }
-  }
-}
 
 //==========================================================
 void Pic::pre_regrid() {
@@ -776,7 +639,7 @@ void Pic::fill_E_B_fields() {
 void Pic::fill_particles() {
   inject_particles_for_new_cells();
   inject_particles_for_boundary_cells();
-  if (useExosphere)
+  if (source || useExosphere)
     fill_source_particles();
 }
 
@@ -788,59 +651,6 @@ void Pic::fill_source_particles() {
 #ifdef _PT_COMPONENT_
   doSelectRegion = (nSpecies == 4);
 #endif
-  if (useExosphere) {
-    int iElec = -1;
-    for (int i = 0; i < nSpecies; ++i) {
-      if (parts[i] && parts[i]->get_charge() < 0) {
-        iElec = i;
-        break;
-      }
-    }
-
-    for (size_t iInfo = 0; iInfo < exoInfos.size(); ++iInfo) {
-      auto& info = exoInfos[iInfo];
-      if (info.iSpecies > 0 && info.iSpecies <= nSpecies) {
-        int iSp = info.iSpecies - 1;
-        if (iSp == iElec) {
-          // Electrons are handled automatically in pair-injection with ions.
-          continue;
-        }
-
-        Real dt = tc->get_dt();
-        Real weightMacro =
-            (info.nMacroParticlesPerDt > 0)
-                ? (info.totalProductionRate * dt / info.nMacroParticlesPerDt)
-                : 1.0;
-        for (int iLev = 0; iLev < n_lev(); iLev++) {
-          if (iSp >= parts.size() || !parts[iSp])
-            continue;
-
-          Real T0_K = info.T0.empty() ? 0.0 : info.T0[0];
-          Real mass_kg =
-              parts[iSp]->get_mass() * fi->get_No2SiM(); // PIC mass unit -> kg
-          Real uth_SI = (T0_K > 0 && mass_kg > 0)
-                            ? sqrt(cBoltzmannSI * T0_K / mass_kg)
-                            : 0.0;
-          Real uth = uth_SI * fi->get_Si2NoV(); // SI -> PIC normalized
-
-          Real uth_elec = 0.0;
-          PicParticles* elec_ptr = nullptr;
-          if (iElec >= 0 && parts[iSp]->get_charge() > 0) {
-            elec_ptr = parts[iElec].get();
-            Real m_elec_kg = elec_ptr->get_mass() * fi->get_No2SiM();
-            Real uth_elec_SI = (T0_K > 0 && m_elec_kg > 0)
-                                   ? sqrt(cBoltzmannSI * T0_K / m_elec_kg)
-                                   : 0.0;
-            uth_elec = uth_elec_SI * fi->get_Si2NoV();
-          }
-
-          parts[iSp]->add_particles_exosphere(exoDensity[iLev], dt, iLev,
-                                              weightMacro, iInfo, uth, elec_ptr,
-                                              uth_elec);
-        }
-      }
-    }
-  }
 
   if (source) {
     for (int i = 0; i < nSpecies; ++i) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,7 +118,6 @@ int main(int argc, char* argv[]) {
     domain.write_plots(true);
   }
 
-  fleksDomains.clear();
   Finalize();
-  return 0;
+  std::_Exit(0);
 }

--- a/tests/test_standalone/validate_tests.py
+++ b/tests/test_standalone/validate_tests.py
@@ -18,9 +18,21 @@ def prepare_run_dir():
     run_dir = "run_test"
     os.makedirs(run_dir, exist_ok=True)
     
+    # Determine the location of the share and bin directories relative to FLEKS root.
+    # In a standalone FLEKS repository, 'share/Scripts/PostProc.pl' is directly inside the working directory.
+    # In SWMF integrated environment, 'share' and 'bin' are located in SWMF root, i.e., two levels above FLEKS root.
+    if os.path.isfile("share/Scripts/PostProc.pl"):
+        postproc_target = "../share/Scripts/PostProc.pl"
+        pidl_target = "../../share/Scripts/pIDL"
+        postidl_target = "../../bin/PostIDL.exe"
+    else:
+        postproc_target = "../../../share/Scripts/PostProc.pl"
+        pidl_target = "../../../../share/Scripts/pIDL"
+        postidl_target = "../../../../bin/PostIDL.exe"
+
     # Symlinks in run directory
     safe_symlink("../bin/FLEKS.exe", os.path.join(run_dir, "FLEKS.exe"))
-    safe_symlink("../../../share/Scripts/PostProc.pl", os.path.join(run_dir, "PostProc.pl"))
+    safe_symlink(postproc_target, os.path.join(run_dir, "PostProc.pl"))
     
     # Component plot and restart directories
     pc_dir = os.path.join(run_dir, "PC")
@@ -29,8 +41,8 @@ def prepare_run_dir():
     os.makedirs(os.path.join(pc_dir, "restartOUT"), exist_ok=True)
     
     # Symlinks in component directory
-    safe_symlink("../../../../share/Scripts/pIDL", os.path.join(pc_dir, "pIDL"))
-    safe_symlink("../../../../bin/PostIDL.exe", os.path.join(pc_dir, "PostIDL.exe"))
+    safe_symlink(pidl_target, os.path.join(pc_dir, "pIDL"))
+    safe_symlink(postidl_target, os.path.join(pc_dir, "PostIDL.exe"))
 
 def cleanup_run_dir():
     """Remove simulation output files from run_test/ after each test.


### PR DESCRIPTION
This refactoring replaces the custom, hardcoded cell-centered exosphere neutral production spawning logic in  `Pic`
 and  `Particles`  with a clean, polymorphic grid-based source term. By introducing  `ExosphereSource`  as a derived class of  `SourceInterface` , we encapsulate all analytical exosphere profiles (exponential, power-law, Chamberlain) and leverage standard grid-to-particle spawning routines.

1. New  `ExosphereSource`  Class ( `include/ExosphereSource.h` ):
  - Inherits from  `SourceInterface` .
  - Calculates exosphere density and pressure shapes directly on the node-centered grid ( `nodeFluid` ).
  - Performs a mathematically exact corner-averaging cell integration loop to evaluate the global physical
      production rate, matching the exact spatial grid interpolation used by AMReX during particle spawning.
  - Dynamically scales production rates to exact physical units using normalized factors, supporting self-
      consistent neutralizing electron density/pressure calculations when kinetic electrons are enabled.
2. Polymorphic Spawning Integration ( `src/Domain.cpp` ):
  - Conditionally instantiates  `ExosphereSource`  when  `useExosphere`  is enabled, decoupling solver architecture
      from hardcoded exosphere checks.
3. Cleanup of Solver Logic ( `src/Pic.cpp` ,  `src/Particles.cpp` , headers):
  - Eliminated custom cell-centered  `exoDensity`  MultiFabs, custom allocation loops, and helper methods.
  - Removed custom spawning loops ( `add_particles_exosphere` ) in favor of generic source-driven particle
      injection ( `add_particles_source`  and  `add_particles_cell` ).
  - Implemented a target PPC fallback in  `add_particles_cell`  for cases where background particle counts are
      initialized to zero (e.g. pickup inflow).

---

- Defined a new inline helper `function  calculate_charge_exchange_cross_section`  in `Particles.h` to unify the Lindsay-Stebbings (LS) and McNutt-Tsinganos (MT) cross-section calculations. This cleanly pulls the formula out of the individual source files and avoids hardcoding different proton/ion mass constants.
- Updated `Particles::charge_exchange_dis` in `Particles.cpp` to use the centralized helper function, eliminating duplicate code and unifying constants.
- In `Pic::exosphere_charge_exchange`  in `Pic.cpp`, we removed the inline lambda `get_cx_cross_section` completely and replaced it with a call to our centralized helper.
- In `Particles.cpp`, we added an early-return check to ensure that neutral-fluid coupling charge exchange is only executed on neutral species.
- To differentiate the SWMF OH-PT coupling charge exchange from the analytical exosphere charge exchange
  - Renamed `Pic::charge_exchange()` to `Pic::coupling_charge_exchange()`  in `Pic.h` and `Pic.cpp`.
  - Updated the call site in `Pic.cpp` inside the advance loop.