### PR TITLE
Feat: loss term and generic chemical reaction support

### DIFF
--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -81,9 +81,7 @@ jobs:
         if: steps.cache-standalone.outputs.cache-hit != 'true'
         working-directory: SWMF/PC/FLEKS
         run: |
-          ./Config.pl -u=exo
           make EXE -j$(nproc)
-          make PIDL
 
       - name: Run Standalone Performance Checks
         working-directory: SWMF/PC/FLEKS/tests

--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -81,7 +81,9 @@ jobs:
         if: steps.cache-standalone.outputs.cache-hit != 'true'
         working-directory: SWMF/PC/FLEKS
         run: |
+          ./Config.pl -u=exo
           make EXE -j$(nproc)
+          make PIDL
 
       - name: Run Standalone Performance Checks
         working-directory: SWMF/PC/FLEKS/tests

--- a/.github/workflows/standalone_test.yml
+++ b/.github/workflows/standalone_test.yml
@@ -71,12 +71,17 @@ jobs:
         id: cache-standalone
         uses: actions/cache@v5
         with:
+          # In the CI, FLEKS is built inside the SWMF tree (not standalone).
+          # make PIDL installs PostIDL.exe to the SWMF-level bin directory
+          # (SWMF/bin/), not the component-level bin (SWMF/PC/FLEKS/bin/).
+          # The test script (validate_tests.py) searches candidate locations
+          # and finds PostIDL.exe at SWMF/bin/PostIDL.exe.
           path: |
             SWMF/PC/FLEKS/bin/FLEKS.exe
-            SWMF/PC/FLEKS/bin/PostIDL.exe
-          key: ${{ runner.os }}-fleks-standalone-${{ hashFiles('SWMF/PC/FLEKS/**/*.cpp', 'SWMF/PC/FLEKS/**/*.h', 'SWMF/PC/FLEKS/**/Makefile*') }}
+            SWMF/bin/PostIDL.exe
+          key: ${{ runner.os }}-fleks-standalone-v2-${{ hashFiles('SWMF/PC/FLEKS/**/*.cpp', 'SWMF/PC/FLEKS/**/*.h', 'SWMF/PC/FLEKS/**/Makefile*') }}
           restore-keys: |
-            ${{ runner.os }}-fleks-standalone-
+            ${{ runner.os }}-fleks-standalone-v2-
 
       - name: Build Standalone FLEKS
         if: steps.cache-standalone.outputs.cache-hit != 'true'

--- a/.github/workflows/standalone_test.yml
+++ b/.github/workflows/standalone_test.yml
@@ -82,7 +82,7 @@ jobs:
         if: steps.cache-standalone.outputs.cache-hit != 'true'
         working-directory: SWMF/PC/FLEKS
         run: |
-          Config.pl -u=Exo
+          ./Config.pl -u=Exo
           make EXE -j$(nproc)
           make PIDL
 

--- a/.github/workflows/standalone_test.yml
+++ b/.github/workflows/standalone_test.yml
@@ -82,6 +82,7 @@ jobs:
         if: steps.cache-standalone.outputs.cache-hit != 'true'
         working-directory: SWMF/PC/FLEKS
         run: |
+          Config.pl -u=Exo
           make EXE -j$(nproc)
           make PIDL
 

--- a/PARAM.XML
+++ b/PARAM.XML
@@ -1205,9 +1205,9 @@ The coefficients n0, H0, T0, k0 are specified as multi-component arrays
 for each neutral species. The total neutral density at radius $r$ (measured
 from the planet center, with $r \geq r_{planet}$) is the sum over all
 nComponent species:
-
-\[ n(r) = \sum_i n_i(r) \]
-
+$$
+  n(r) = \sum_i n_i(r)
+$$
 where each component density $n_i(r)$ depends on typeProfile:
 
 \begin{verbatim}
@@ -1333,7 +1333,7 @@ Uses a constant cross-section model:
 \begin{verbatim}
 <sigma*v> = sigmaCX * u_ion
 \end{verbatim}
-sigmaCX is the charge exchange cross section [cm$^2$], specified as a
+sigmaCX is the charge exchange cross section [cm\^2], specified as a
 matrix with one row per neutral component (in #EXOSPHERE order) and one
 column per ion species, in row-major order.  Each neutral component
 exchanges charge with every ion species, and the total charge-exchange
@@ -1373,7 +1373,7 @@ nReactions is the number of recombination reactions.  For each reaction,
 the following 4 parameters are read:
   ionSpecies    - 1-based ion species index (1..nS-1).  Species 0 (the
                   electron) cannot recombine with itself.
-  rateCoef      - Base rate coefficient k0 [cm$^3$/s].
+  rateCoef      - Base rate coefficient k0 [cm\^3/s].
   tempExponent  - Temperature exponent alpha.  When 0, k = k0 (constant,
                   independent of temperature).  When non-zero, refTemp
                   must be positive.

--- a/PARAM.XML
+++ b/PARAM.XML
@@ -1332,6 +1332,139 @@ nu_CX(iC) = sum_{iSp} n_{iSp} * sigmaCX(iC, iSp) * u_{iSp}.
 The resulting source is deposited into the mapped ion species (iC + 1).
 </command>
 
+<command name="RECOMBINATION"
+	 alias="RECOMBINATION_FLEKS0,RECOMBINATION_FLEKS1,RECOMBINATION_FLEKS2"
+	 multiple="T">
+  <parameter name="nReactions" type="integer"/>
+  <parameter name="ionSpecies" type="integer"/>
+  <parameter name="rateCoef" type="real"/>
+  <parameter name="tempExponent" type="real"/>
+  <parameter name="refTemp" type="real"/>
+
+#RECOMBINATION
+1                       nReactions
+2                       ionSpecies    O2+ (species 2)
+7.38e-3                 rateCoef      [cm^3/s]
+0.56                    tempExponent
+300.0                   refTemp       [K]
+
+This command enables dissociative recombination as a source process:
+ion+ + e- -> neutrals.  It requires useElectronFluid = true, i.e. species 0
+must be the electron (set via #PLASMA with a negative charge).  The electron
+density n_e and temperature T_e are taken from the electron fluid.  The
+recombing ion is consumed (a loss term written to the particle loss array),
+and the neutral products are not tracked as fluids.  The electron density
+decrease is handled implicitly by the quasi-neutrality condition, so only
+the ion species needs to be listed.
+
+nReactions is the number of recombination reactions.  For each reaction,
+the following 4 parameters are read:
+  ionSpecies    - 1-based ion species index (1..nS-1).  Species 0 (the
+                  electron) cannot recombine with itself.
+  rateCoef      - Base rate coefficient k0 [cm^3/s].
+  tempExponent  - Temperature exponent alpha.  When 0, k = k0 (constant,
+                  independent of temperature).  When non-zero, refTemp
+                  must be positive.
+  refTemp       - Reference temperature T_ref [K].
+
+The temperature-dependent rate coefficient is:
+  k(T_e) = k0 * (T_ref / T_e)^alpha
+where T_e is the electron temperature in Kelvin.
+
+#RECOMBINATION does not require #EXOSPHERE because recombination depends
+on the electron and ion fluids, not on the neutral exosphere.  #PLASMA
+must appear before #RECOMBINATION so that the ion species indices and the
+electron fluid flag can be validated.
+</command>
+
+<command name="CHEMISTRY"
+	 alias="CHEMISTRY_FLEKS0,CHEMISTRY_FLEKS1,CHEMISTRY_FLEKS2"
+	 multiple="T">
+  <parameter name="nReactions" type="integer"/>
+  <parameter name="reactantIon" type="integer"/>
+  <parameter name="productIon" type="integer"/>
+  <parameter name="neutralComp" type="integer"/>
+  <parameter name="rateType" type="integer"/>
+  <parameter name="rateCoef" type="real"/>
+  <parameter name="tempExp" type="real"/>
+  <parameter name="refTemp" type="real"/>
+
+#CHEMISTRY
+3                       nReactions
+0                       reactantIon   R1: CO2 + hv   -> CO2+ + e-  (photoionization)
+4                       productIon
+2                       neutralComp
+1                       rateType
+2.47e-2                 rateCoef      nu0 [s^-1]
+0.0                     tempExp
+0.0                     refTemp
+4                       reactantIon   R2: CO2+ + O   -> O2+  + CO   (charge exchange)
+3                       productIon
+1                       neutralComp
+0                       rateType
+1.64e-5                 rateCoef      k0 [cm^3/s]
+0.0                     tempExp
+0.0                     refTemp
+3                       reactantIon   R3: O2+ + e-   -> O    + O    (recombination)
+0                       productIon
+-1                      neutralComp
+0                       rateType
+7.38e-3                 rateCoef      k0 [cm^3/s]
+0.56                    tempExp
+300.0                   refTemp
+
+This command provides a unified chemistry framework that supports
+photoionization, charge exchange (cross-species ion conversion), and
+recombination through a single reaction table.  It requires
+useElectronFluid = true (species 0 = electron, set via #PLASMA).  The
+electron density n_e and temperature T_e are taken from the electron
+fluid, and electron density changes are handled implicitly by the
+quasi-neutrality condition — only ion species need to be listed as
+reactants or products.
+
+nReactions is the number of reactions.  For each reaction, the following
+7 parameters are read:
+  reactantIon  - Consumed ion species index: 0 = none (photoionization),
+                 1..nS-1 = ion species.
+  productIon   - Produced ion species index: 0 = none (recombination),
+                 1..nS-1 = ion species.
+  neutralComp  - Exosphere neutral component: -1 = none (recombination),
+                 0..nComponent-1 = #EXOSPHERE component index.
+  rateType     - 0 = thermal rate k(T_e); 1 = photoionization (1/r^2).
+  rateCoef     - k0 [cm^3/s] for thermal; nu0 [s^-1] at the planet
+                 surface for photoionization.
+  tempExp      - Temperature exponent alpha (thermal only).  When 0,
+                 k = k0 (constant).  When non-zero, refTemp > 0 is
+                 required.
+  refTemp      - Reference temperature T_ref [K] (thermal only).
+
+The rate coefficient for thermal reactions (rateType = 0) is:
+  k(T_e) = k0 * (T_ref / T_e)^alpha
+For photoionization (rateType = 1), the rate follows geometric dilution:
+  nu(r) = nu0 * (r_planet / r)^2
+and is set to zero inside the shadow cylinder defined by #SHADOWCYLINDER
+(if present).
+
+Three reaction categories are supported:
+  1. Photoionization (reactantIon = 0, rateType = 1):
+     neutral + hv -> ion+ + e-.  The neutral is at rest; the produced ion
+     inherits the neutral temperature (T0 from #EXOSPHERE).  neutralComp
+     must be >= 0.
+  2. Charge exchange / ion conversion (reactantIon > 0, productIon > 0,
+     rateType = 0): ion1+ + neutral -> ion2+ + neutral'.  The product ion
+     inherits the reactant ion's velocity and temperature.  neutralComp
+     must be >= 0.
+  3. Recombination (reactantIon > 0, productIon = 0, neutralComp = -1,
+     rateType = 0): ion+ + e- -> neutrals.  The ion is consumed; the rate
+     is k * n_e.  No neutral component is needed.
+
+#EXOSPHERE must appear before #CHEMISTRY if any reaction uses
+neutralComp >= 0.  #PLASMA must also appear before #CHEMISTRY.  #CHEMISTRY
+supersedes the simpler #PHOTOIONIZATION, #CHARGEEXCHANGE, and
+#RECOMBINATION commands; use either the unified #CHEMISTRY table or the
+individual commands, not both.
+</command>
+
 <command name="PLASMA"
 	 alias="PLASMA_FLEKS0,PLASMA_FLEKS1,PLASMA_FLEKS2"
 	 multiple="T">
@@ -1393,9 +1526,15 @@ neutral species.
 0.0                 Ez [?]
 
 If PIC is not initialized from SWMF (#INITFROMSWMF), set uniform initial
-conditions here. This command has only been tested with neutral particles
-(OH-PT coupling) so far. The units of B and E are SI, and it is likely
-they will be changed to other units in the future.
+conditions here. For each plasma species, provide rho [amu/cc], ux/uy/uz
+[km/s], and T [K]. The background electromagnetic fields B [T] and E [V/m]
+are specified once at the end (in SI units).
+
+When useElectronFluid is enabled, the electron species (species 0) density
+is read directly from its rho value rather than being computed from a
+quasi-neutrality condition. The user is responsible for ensuring charge
+neutrality, i.e. rho_e = (sum_i rho_i / m_i) * m_e, where m_e and m_i are
+the species masses declared in #PLASMA.
 </command>
 
 

--- a/PARAM.XML
+++ b/PARAM.XML
@@ -1202,14 +1202,15 @@ Exponential      typeProfile
 This command configures the static exospheric neutral density profile.
 The typeProfile can be "Exponential", "Power-Law", or "Chamberlain".
 The coefficients n0, H0, T0, k0 are specified as multi-component arrays
-for each neutral species. The total neutral density at radius r (measured
-from the planet center, with r >= r_planet) is the sum over all
+for each neutral species. The total neutral density at radius $r$ (measured
+from the planet center, with $r \geq r_{planet}$) is the sum over all
 nComponent species:
 
-  n(r) = sum_i n_i(r)
+$ n(r) = \sum_i n_i(r) $
 
-where each component density n_i(r) depends on typeProfile:
+where each component density $n_i(r)$ depends on typeProfile:
 
+\begin{verbatim}
   Exponential (uses n0, H0):
     n_i(r) = n0_i * exp(-(r - r_planet) / H0_i)
 
@@ -1218,14 +1219,15 @@ where each component density n_i(r) depends on typeProfile:
 
   Chamberlain (uses n0, H0):
     n_i(r) = n0_i * exp(-H0_i * (1/r_planet - 1/r))
+\end{verbatim}
 
-Here r_planet is the body radius set by #BODYSIZE, n0_i is the surface
-number density [m^-3] at r = r_planet, H0_i is the scale height [m],
-and k0_i is the power-law index. T0_i is the neutral temperature [K] of
+Here $r_{planet}$ is the body radius set by #BODYSIZE, $n0_i$ is the surface
+number density [m$^{-3}$] at $r = r_{planet}$, $H0_i$ is the scale height [m],
+and $k0_i$ is the power-law index. $T0_i$ is the neutral temperature [K] of
 the exosphere component. It is used as the ionization source temperature:
-the pressure of newly created ions is set to n * k_B * T0_i. T0_i must
-be positive whenever any ionization source process is enabled. To enable
-ionization source processes, use the separate #PHOTOIONIZATION,
+the pressure of newly created ions is set to $n \times k_B \times T0_i$. $T0_i$
+must be positive whenever any ionization source process is enabled. To
+enable ionization source processes, use the separate #PHOTOIONIZATION,
 #ELECTRONIMPACT, and/or #CHARGEEXCHANGE commands below. If none of those
 commands are present, no ionization source is applied.
 </command>
@@ -1244,8 +1246,10 @@ The number of neutral components is taken from #EXOSPHERE (nComponent);
 #EXOSPHERE must appear before #PHOTOIONIZATION in PARAM.in.
 nuPhoto0 is the photoionization rate [1/s] at the planet surface,
 specified as a multi-component array (one value per #EXOSPHERE component,
-in the same order). The rate at distance r follows geometric dilution:
-nu(r) = nuPhoto0 * (r_planet / r)^2.
+in the same order). The rate at distance $r$ follows geometric dilution:
+\begin{verbatim}
+nu(r) = nuPhoto0 * (r_planet / r)^2
+\end{verbatim}
 </command>
 
 <command name="SHADOWCYLINDER"
@@ -1296,9 +1300,12 @@ symmetrically (no shadow).
 This command enables electron impact ionization as an exosphere source
 process. The number of neutral components is taken from #EXOSPHERE
 (nComponent); #EXOSPHERE must appear before #ELECTRONIMPACT in PARAM.in.
-Uses the Voronov 1997 rate coefficient: <sigma*v> = A * t^K / (X + t)
-* exp(-Ei/Te), where t = Te/Ei.  eIon is the ionization energy [eV],
-Acoeff is the Voronov A coefficient [cm^3/s], Kcoeff is K, Xcoeff is X.
+Uses the Voronov 1997 rate coefficient:
+\begin{verbatim}
+<sigma*v> = A * t^K / (X + t) * exp(-Ei/Te),  where t = Te/Ei
+\end{verbatim}
+eIon is the ionization energy [eV], Acoeff is the Voronov A coefficient
+[cm$^3$/s], Kcoeff is K, Xcoeff is X.
 Each parameter is specified as a multi-component array (one set per
 #EXOSPHERE component, in the same order).
 </command>
@@ -1322,13 +1329,18 @@ The number of neutral components is taken from #EXOSPHERE (nComponent);
 nIonSpecies must match the number of ion species (nS - 1 from #PLASMA,
 since species 0 is the electron); #PLASMA must also appear before
 #CHARGEEXCHANGE.
-Uses a constant cross-section model: <sigma*v> = sigmaCX * u_ion.
-sigmaCX is the charge exchange cross section [cm^2], specified as a
+Uses a constant cross-section model:
+\begin{verbatim}
+<sigma*v> = sigmaCX * u_ion
+\end{verbatim}
+sigmaCX is the charge exchange cross section [cm$^2$], specified as a
 matrix with one row per neutral component (in #EXOSPHERE order) and one
 column per ion species, in row-major order.  Each neutral component
 exchanges charge with every ion species, and the total charge-exchange
 frequency for a neutral component is the sum over all ion species:
-nu_CX(iC) = sum_{iSp} n_{iSp} * sigmaCX(iC, iSp) * u_{iSp}.
+\begin{verbatim}
+nu_CX(iC) = sum_{iSp} n_{iSp} * sigmaCX(iC, iSp) * u_{iSp}
+\end{verbatim}
 The resulting source is deposited into the mapped ion species (iC + 1).
 </command>
 
@@ -1351,7 +1363,7 @@ The resulting source is deposited into the mapped ion species (iC + 1).
 This command enables dissociative recombination as a source process:
 ion+ + e- -> neutrals.  It requires useElectronFluid = true, i.e. species 0
 must be the electron (set via #PLASMA with a negative charge).  The electron
-density n_e and temperature T_e are taken from the electron fluid.  The
+density $n_e$ and temperature $T_e$ are taken from the electron fluid.  The
 recombing ion is consumed (a loss term written to the particle loss array),
 and the neutral products are not tracked as fluids.  The electron density
 decrease is handled implicitly by the quasi-neutrality condition, so only
@@ -1361,15 +1373,17 @@ nReactions is the number of recombination reactions.  For each reaction,
 the following 4 parameters are read:
   ionSpecies    - 1-based ion species index (1..nS-1).  Species 0 (the
                   electron) cannot recombine with itself.
-  rateCoef      - Base rate coefficient k0 [cm^3/s].
+  rateCoef      - Base rate coefficient k0 [cm$^3$/s].
   tempExponent  - Temperature exponent alpha.  When 0, k = k0 (constant,
                   independent of temperature).  When non-zero, refTemp
                   must be positive.
-  refTemp       - Reference temperature T_ref [K].
+  refTemp       - Reference temperature $T_{ref}$ [K].
 
 The temperature-dependent rate coefficient is:
+\begin{verbatim}
   k(T_e) = k0 * (T_ref / T_e)^alpha
-where T_e is the electron temperature in Kelvin.
+\end{verbatim}
+where $T_e$ is the electron temperature in Kelvin.
 
 #RECOMBINATION does not require #EXOSPHERE because recombination depends
 on the electron and ion fluids, not on the neutral exosphere.  #PLASMA
@@ -1417,7 +1431,7 @@ This command provides a unified chemistry framework that supports
 photoionization, charge exchange (cross-species ion conversion), and
 recombination through a single reaction table.  It requires
 useElectronFluid = true (species 0 = electron, set via #PLASMA).  The
-electron density n_e and temperature T_e are taken from the electron
+electron density $n_e$ and temperature $T_e$ are taken from the electron
 fluid, and electron density changes are handled implicitly by the
 quasi-neutrality condition — only ion species need to be listed as
 reactants or products.
@@ -1430,18 +1444,22 @@ nReactions is the number of reactions.  For each reaction, the following
                  1..nS-1 = ion species.
   neutralComp  - Exosphere neutral component: -1 = none (recombination),
                  0..nComponent-1 = #EXOSPHERE component index.
-  rateType     - 0 = thermal rate k(T_e); 1 = photoionization (1/r^2).
-  rateCoef     - k0 [cm^3/s] for thermal; nu0 [s^-1] at the planet
+  rateType     - 0 = thermal rate $k(T_e)$; 1 = photoionization $(1/r^2)$.
+  rateCoef     - k0 [cm$^3$/s] for thermal; nu0 [s$^{-1}$] at the planet
                  surface for photoionization.
   tempExp      - Temperature exponent alpha (thermal only).  When 0,
                  k = k0 (constant).  When non-zero, refTemp > 0 is
                  required.
-  refTemp      - Reference temperature T_ref [K] (thermal only).
+  refTemp      - Reference temperature $T_{ref}$ [K] (thermal only).
 
 The rate coefficient for thermal reactions (rateType = 0) is:
+\begin{verbatim}
   k(T_e) = k0 * (T_ref / T_e)^alpha
+\end{verbatim}
 For photoionization (rateType = 1), the rate follows geometric dilution:
+\begin{verbatim}
   nu(r) = nu0 * (r_planet / r)^2
+\end{verbatim}
 and is set to zero inside the shadow cylinder defined by #SHADOWCYLINDER
 (if present).
 
@@ -1456,7 +1474,7 @@ Three reaction categories are supported:
      must be >= 0.
   3. Recombination (reactantIon > 0, productIon = 0, neutralComp = -1,
      rateType = 0): ion+ + e- -> neutrals.  The ion is consumed; the rate
-     is k * n_e.  No neutral component is needed.
+     is $k \times n_e$.  No neutral component is needed.
 
 #EXOSPHERE must appear before #CHEMISTRY if any reaction uses
 neutralComp >= 0.  #PLASMA must also appear before #CHEMISTRY.  #CHEMISTRY

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -356,6 +356,12 @@ public:
       amrex::Vector<std::unique_ptr<PicParticles> >& sourceParts,
       bool doSelectRegion, int nppc, amrex::Real& maxExchangeRatio);
 
+  /// Apply chemical loss (recombination, etc.) by reducing particle
+  /// weights proportionally.  Reads per-ion loss rates from
+  /// source->nodeLossFluid and reduces each particle's weight by
+  /// fraction = min(lossRate * dt / rhoExisting, 1).
+  void apply_loss(const SourceInterface* source, amrex::Real dt);
+
   void accumulate_mass_matrix_contribution(int iLev,
                                            const amrex::IntVect& loIdx,
                                            const amrex::RealVect& dShift,

--- a/include/SourceInterface.h
+++ b/include/SourceInterface.h
@@ -85,8 +85,8 @@ protected:
   // nodeFluid but only has nS-1 components (one per ion species, 0-based:
   // component i = ion species i+1).  Particles::apply_loss() reads this
   // to reduce existing particle weights proportionally.
+  // Allocated whenever useRecombination or useChemistry is true.
   amrex::Vector<amrex::MultiFab> nodeLossFluid;
-  bool useLossSource = false; // true when any loss process is enabled
 
 public:
   SourceInterface(const FluidInterface& other, int id, std::string tag,
@@ -147,7 +147,7 @@ public:
   }
 
   void distribute_loss_arrays() {
-    if (!useLossSource)
+    if (!(useRecombination || useChemistry))
       return;
     if (nodeLossFluid.empty())
       nodeLossFluid.resize(n_lev_max());
@@ -162,7 +162,7 @@ public:
   }
 
   void set_node_loss_fluid_to_zero() {
-    if (!useLossSource)
+    if (!(useRecombination || useChemistry))
       return;
     for (int iLev = 0; iLev < n_lev(); ++iLev) {
       if (!nodeLossFluid[iLev].empty())
@@ -171,7 +171,7 @@ public:
   }
 
   void sum_loss_boundary() {
-    if (!useLossSource)
+    if (!(useRecombination || useChemistry))
       return;
     // Use FillBoundary (copy) instead of SumBoundary (sum) for loss rates.
     // Each node's loss rate is computed independently and should NOT be
@@ -191,11 +191,12 @@ public:
     return arr(ijk, iIon);
   }
 
-  bool use_loss_source() const { return useLossSource; }
+  bool use_loss_source() const { return useRecombination || useChemistry; }
 
   /// Check whether nodeLossFluid is allocated and non-empty at iLev.
   bool has_loss_array(int iLev) const {
-    return useLossSource && iLev < static_cast<int>(nodeLossFluid.size()) &&
+    return (useRecombination || useChemistry) &&
+           iLev < static_cast<int>(nodeLossFluid.size()) &&
            !nodeLossFluid[iLev].empty();
   }
 };

--- a/include/SourceInterface.h
+++ b/include/SourceInterface.h
@@ -60,6 +60,25 @@ protected:
   amrex::Vector<double> recombRefTemp; // reference temperature T_ref [K]
   // k(Te) = k0 * (T_ref / Te_K)^alpha
 
+  // ---- General chemistry (#CHEMISTRY command) ----
+  // Supports cross-species ion conversion, photoionization, and
+  // recombination through a unified reaction format.
+  //   reactantIon + neutral -> productIon + neutral'
+  // reactantIon=0 means no reactant ion (photoionization).
+  // productIon=0 means no product ion (recombination).
+  // neutralComp=-1 means no neutral needed (recombination).
+  bool useChemistry = false;
+  struct ChemistryReaction {
+    int reactantIon;  // 0 = none, 1+ = ion species index
+    int productIon;   // 0 = none, 1+ = ion species index
+    int neutralComp;  // -1 = none, 0+ = exosphere component
+    int rateType;     // 0 = thermal k(T), 1 = photoionization (1/r^2)
+    double rateCoef;  // k0 [cm^3/s] for thermal, nu0 [s^-1] for photo
+    double tempExp;   // alpha: k = k0 * (Tref/Te)^alpha
+    double refTemp;   // T_ref [K]
+  };
+  amrex::Vector<ChemistryReaction> chemReactions;
+
   // ---- Loss term storage ----
   // nodeLossFluid stores the mass-density LOSS RATE (positive = loss)
   // for each ion species, in PIC-normalized units.  It is parallel to

--- a/include/SourceInterface.h
+++ b/include/SourceInterface.h
@@ -69,13 +69,13 @@ protected:
   // neutralComp=-1 means no neutral needed (recombination).
   bool useChemistry = false;
   struct ChemistryReaction {
-    int reactantIon;  // 0 = none, 1+ = ion species index
-    int productIon;   // 0 = none, 1+ = ion species index
-    int neutralComp;  // -1 = none, 0+ = exosphere component
-    int rateType;     // 0 = thermal k(T), 1 = photoionization (1/r^2)
-    double rateCoef;  // k0 [cm^3/s] for thermal, nu0 [s^-1] for photo
-    double tempExp;   // alpha: k = k0 * (Tref/Te)^alpha
-    double refTemp;   // T_ref [K]
+    int reactantIon; // 0 = none, 1+ = ion species index
+    int productIon;  // 0 = none, 1+ = ion species index
+    int neutralComp; // -1 = none, 0+ = exosphere component
+    int rateType;    // 0 = thermal k(T), 1 = photoionization (1/r^2)
+    double rateCoef; // k0 [cm^3/s] for thermal, nu0 [s^-1] for photo
+    double tempExp;  // alpha: k = k0 * (Tref/Te)^alpha
+    double refTemp;  // T_ref [K]
   };
   amrex::Vector<ChemistryReaction> chemReactions;
 
@@ -185,9 +185,8 @@ public:
 
   /// Read loss rate for ion species iIon (0-based) at cell ijk.
   /// Returns the normalized mass-density loss rate (positive = loss).
-  amrex::Real get_loss_value(const amrex::MFIter& mfi,
-                             const amrex::IntVect ijk, const int iIon,
-                             const int iLev = 0) const {
+  amrex::Real get_loss_value(const amrex::MFIter& mfi, const amrex::IntVect ijk,
+                             const int iIon, const int iLev = 0) const {
     const auto& arr = nodeLossFluid[iLev][mfi].const_array();
     return arr(ijk, iIon);
   }
@@ -196,8 +195,7 @@ public:
 
   /// Check whether nodeLossFluid is allocated and non-empty at iLev.
   bool has_loss_array(int iLev) const {
-    return useLossSource &&
-           iLev < static_cast<int>(nodeLossFluid.size()) &&
+    return useLossSource && iLev < static_cast<int>(nodeLossFluid.size()) &&
            !nodeLossFluid[iLev].empty();
   }
 };

--- a/include/SourceInterface.h
+++ b/include/SourceInterface.h
@@ -49,6 +49,26 @@ protected:
   // the fluid index).
   amrex::Vector<double> cxSigma;
 
+  // ---- Recombination (#RECOMBINATION command) ----
+  // Dissociative recombination: ion+ + e- -> neutrals.
+  // Requires useElectronFluid = true (species 0 = electron).
+  bool useRecombination = false;
+  // Per-reaction parameters (parallel arrays, size = nRecombReactions):
+  amrex::Vector<int> recombIonIndex;   // 1-based ion species index (iSp)
+  amrex::Vector<double> recombRate0;   // base rate coefficient k0 [cm^3/s]
+  amrex::Vector<double> recombTempExp; // temperature exponent alpha
+  amrex::Vector<double> recombRefTemp; // reference temperature T_ref [K]
+  // k(Te) = k0 * (T_ref / Te_K)^alpha
+
+  // ---- Loss term storage ----
+  // nodeLossFluid stores the mass-density LOSS RATE (positive = loss)
+  // for each ion species, in PIC-normalized units.  It is parallel to
+  // nodeFluid but only has nS-1 components (one per ion species, 0-based:
+  // component i = ion species i+1).  Particles::apply_loss() reads this
+  // to reduce existing particle weights proportionally.
+  amrex::Vector<amrex::MultiFab> nodeLossFluid;
+  bool useLossSource = false; // true when any loss process is enabled
+
 public:
   SourceInterface(const FluidInterface& other, int id, std::string tag,
                   FluidType typeIn = SourceFluid)
@@ -95,6 +115,71 @@ public:
   /// Default returns 0.0 — override in UserSource for exosphere profiles.
   virtual double get_exosphere_component_density(double r, int iC) const {
     return 0.0;
+  }
+
+  // ---- Loss term management ----
+  // These methods manage nodeLossFluid, which stores per-ion mass-density
+  // loss rates for apply_loss() to consume.  The layout and distribution
+  // parallel nodeFluid but with only nS-1 components (ions only).
+
+  void post_regrid() override {
+    FluidInterface::post_regrid(); // distributes nodeFluid
+    distribute_loss_arrays();
+  }
+
+  void distribute_loss_arrays() {
+    if (!useLossSource)
+      return;
+    if (nodeLossFluid.empty())
+      nodeLossFluid.resize(n_lev_max());
+    const int nIon = nS > 1 ? nS - 1 : 0;
+    if (nIon == 0)
+      return;
+    const bool doCopy = true;
+    for (int iLev = 0; iLev < n_lev(); iLev++) {
+      distribute_FabArray(nodeLossFluid[iLev], nGrids[iLev],
+                          DistributionMap(iLev), nIon, nGst, doCopy);
+    }
+  }
+
+  void set_node_loss_fluid_to_zero() {
+    if (!useLossSource)
+      return;
+    for (int iLev = 0; iLev < n_lev(); ++iLev) {
+      if (!nodeLossFluid[iLev].empty())
+        nodeLossFluid[iLev].setVal(0.0);
+    }
+  }
+
+  void sum_loss_boundary() {
+    if (!useLossSource)
+      return;
+    // Use FillBoundary (copy) instead of SumBoundary (sum) for loss rates.
+    // Each node's loss rate is computed independently and should NOT be
+    // summed across shared/periodic nodes.  FillBoundary fills ghost cells
+    // with the correct values from the interior, handling periodic BCs.
+    for (int iLev = 0; iLev < n_lev(); ++iLev) {
+      if (!nodeLossFluid[iLev].empty())
+        nodeLossFluid[iLev].FillBoundary(Geom(iLev).periodicity());
+    }
+  }
+
+  /// Read loss rate for ion species iIon (0-based) at cell ijk.
+  /// Returns the normalized mass-density loss rate (positive = loss).
+  amrex::Real get_loss_value(const amrex::MFIter& mfi,
+                             const amrex::IntVect ijk, const int iIon,
+                             const int iLev = 0) const {
+    const auto& arr = nodeLossFluid[iLev][mfi].const_array();
+    return arr(ijk, iIon);
+  }
+
+  bool use_loss_source() const { return useLossSource; }
+
+  /// Check whether nodeLossFluid is allocated and non-empty at iLev.
+  bool has_loss_array(int iLev) const {
+    return useLossSource &&
+           iLev < static_cast<int>(nodeLossFluid.size()) &&
+           !nodeLossFluid[iLev].empty();
   }
 };
 

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -905,7 +905,7 @@ void Domain::read_param(const bool readGridInfo) {
         pt->read_param(command, param);
     } else if (command == "#PHOTOIONIZATION" || command == "#ELECTRONIMPACT" ||
                command == "#CHARGEEXCHANGE" || command == "#SHADOWCYLINDER" ||
-               command == "#RECOMBINATION") {
+               command == "#RECOMBINATION" || command == "#CHEMISTRY") {
       if (source) {
         // Sync exosphere/plasma parameters from fi to source so that
         // source->read_param() can access nExoComponent (set by #EXOSPHERE)

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -221,6 +221,7 @@ void Domain::update() {
   if (source && !initFromSWMF) {
     source->set_source(*fi);
     source->sum_boundary();
+    source->sum_loss_boundary();
     source->convert_moment_to_velocity(true, false);
   }
 
@@ -498,6 +499,7 @@ void Domain::set_state_var(double *data, int *index,
     if (source && !stateOH) {
       source->set_source(*fi);
       source->sum_boundary();
+      source->sum_loss_boundary();
       source->convert_moment_to_velocity(true, false);
     }
   }
@@ -902,7 +904,8 @@ void Domain::read_param(const bool readGridInfo) {
       if (pt)
         pt->read_param(command, param);
     } else if (command == "#PHOTOIONIZATION" || command == "#ELECTRONIMPACT" ||
-               command == "#CHARGEEXCHANGE" || command == "#SHADOWCYLINDER") {
+               command == "#CHARGEEXCHANGE" || command == "#SHADOWCYLINDER" ||
+               command == "#RECOMBINATION") {
       if (source) {
         // Sync exosphere/plasma parameters from fi to source so that
         // source->read_param() can access nExoComponent (set by #EXOSPHERE)

--- a/src/Particles.cpp
+++ b/src/Particles.cpp
@@ -3938,6 +3938,89 @@ void Particles<NStructReal, NStructInt>::charge_exchange(
   }
 }
 
+//==========================================================
+// Apply chemical loss (recombination, etc.) by proportionally
+// reducing particle weights.  For each cell, reads the ion loss
+// rate from source->nodeLossFluid and the existing ion mass density
+// from fi, then reduces every particle's weight by the fraction
+//   fraction = min(lossRate * dt / rhoExisting, 1.0).
+// Only ion species (charge > 0) are affected; electrons are handled
+// by quasi-neutrality.
+template <int NStructReal, int NStructInt>
+void Particles<NStructReal, NStructInt>::apply_loss(
+    const SourceInterface* source, Real dt) {
+  std::string nameFunc = "Pts::apply_loss";
+  timing_func(nameFunc);
+
+  // Only apply to positively charged ions.
+  if (charge <= 0.0)
+    return;
+
+  if (!source || !source->use_loss_source())
+    return;
+
+  // 0-based ion index in nodeLossFluid: speciesID - 1 (species 0 = electron).
+  const int iIon = speciesID - 1;
+  if (iIon < 0)
+    return;
+
+  for (int iLev = 0; iLev < n_lev(); iLev++) {
+    if (NumberOfParticlesAtLevel(iLev, true, true) == 0)
+      continue;
+
+    if (!source->has_loss_array(iLev))
+      continue;
+
+    const Real* plo = Geom(iLev).ProbLo();
+    const Real* inv_dx = Geom(iLev).InvCellSize();
+
+    for (PIter pti(*this, iLev); pti.isValid(); ++pti) {
+      AoS& particles = pti.GetArrayOfStructs();
+      const int np = particles.numParticles();
+      if (np == 0)
+        continue;
+
+      for (int ip = 0; ip < np; ++ip) {
+        ParticleType& p = particles[ip];
+        if (p.id() < 0)
+          continue;
+
+        // Find the cell index for this particle.
+        IntVect ijk;
+        for (int iDim = 0; iDim < nDim; ++iDim) {
+          ijk[iDim] = static_cast<int>(std::floor(
+              (p.pos(iDim) - plo[iDim]) * inv_dx[iDim]));
+        }
+
+        // Existing ion mass density (normalized) from the plasma state.
+        Real rhoExisting =
+            fi->get_fluid_mass_density(pti, ijk, speciesID, iLev);
+        if (rhoExisting <= 0.0)
+          continue;
+
+        // Loss rate (normalized mass-density rate) from nodeLossFluid.
+        Real lossRate = source->get_loss_value(pti, ijk, iIon, iLev);
+        if (lossRate <= 0.0)
+          continue;
+
+        // Fraction of mass to remove in this step.
+        Real fraction = lossRate * dt / rhoExisting;
+        if (fraction > 1.0)
+          fraction = 1.0;
+        if (fraction <= 0.0)
+          continue;
+
+        // Reduce particle weight proportionally.  The sign is preserved
+        // (ions have positive weight, electrons negative).
+        p.rdata(iqp_) *= (1.0 - fraction);
+      }
+    }
+  }
+
+  // Remove particles whose weight has been driven to (near) zero.
+  redistribute_particles();
+}
+
 template <int NStructReal, int NStructInt>
 void Particles<NStructReal, NStructInt>::add_source_particles(
     std::unique_ptr<PicParticles>& sourcePart, IntVect ppc,

--- a/src/Particles.cpp
+++ b/src/Particles.cpp
@@ -3988,8 +3988,8 @@ void Particles<NStructReal, NStructInt>::apply_loss(
         // Find the cell index for this particle.
         IntVect ijk;
         for (int iDim = 0; iDim < nDim; ++iDim) {
-          ijk[iDim] = static_cast<int>(std::floor(
-              (p.pos(iDim) - plo[iDim]) * inv_dx[iDim]));
+          ijk[iDim] = static_cast<int>(
+              std::floor((p.pos(iDim) - plo[iDim]) * inv_dx[iDim]));
         }
 
         // Existing ion mass density (normalized) from the plasma state.

--- a/src/Pic.cpp
+++ b/src/Pic.cpp
@@ -1301,6 +1301,15 @@ void Pic::update(bool doReportIn) {
 
   charge_exchange();
 
+  // Apply chemical loss (recombination, etc.) by reducing particle
+  // weights.  Must come before fill_source_particles() so that loss
+  // and source are applied in the correct order within one step.
+  if (source && source->use_loss_source()) {
+    for (int i = 0; i < nSpecies; ++i) {
+      parts[i]->apply_loss(source, tc->get_dt());
+    }
+  }
+
   if (source) {
     fill_source_particles();
   }

--- a/tests/chemistry/PARAM.in
+++ b/tests/chemistry/PARAM.in
@@ -1,0 +1,226 @@
+#DESCRIPTION
+Mars Chemistry Test: 10 BATSRUS ModUserMars reactions with 4 ion species
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+-9.0e6                  xMin
+ 9.0e6                  xMax
+-1.0                    yMin
+ 1.0                    yMax
+-1.0                    zMin
+ 1.0                    zMax
+
+#NCELL
+32                      nCellX
+1                       nCellY
+1                       nCellZ
+
+#MAXBLOCKSIZE
+32                      maxBlockSizeX
+1                       maxBlockSizeY
+1                       maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#PLASMA
+5                       nSpecies
+0.01                    mass        Species 0: electron
+-1.0                    charge
+1.0                     mass        Species 1: H+
+1.0                     charge
+16.0                    mass        Species 2: O+
+1.0                     charge
+32.0                    mass        Species 3: O2+
+1.0                     charge
+44.0                    mass        Species 4: CO2+
+1.0                     charge
+
+#UNIFORMSTATE
+0.0558238636363636      rho [amu/cc]   Species 0: electron (quasi-neutral)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+10000.0                 T [K]
+5.0                     rho [amu/cc]   Species 1: H+
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+10000.0                 T [K]
+5.0                     rho [amu/cc]   Species 2: O+
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+10000.0                 T [K]
+5.0                     rho [amu/cc]   Species 3: O2+
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+10000.0                 T [K]
+5.0                     rho [amu/cc]   Species 4: CO2+
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+10000.0                 T [K]
+5.0e-9                  bx [T]
+0.0                     by [T]
+0.0                     bz [T]
+0.0                     ex [V/m]
+0.0                     ey [V/m]
+0.0                     ez [V/m]
+
+#SOURCE
+T                       useSource
+
+#BODYSIZE
+3.0e6                   radius        Mars-like planet radius
+
+#EXOSPHERE
+Chamberlain             typeProfile
+3                       nComponent
+1.0e10                  n0            H component
+2000.0e3                H0
+300.0                   T0
+0.0                     k0
+5.0e10                  n0            O component
+300.0e3                 H0
+300.0                   T0
+0.0                     k0
+5.0e10                  n0            CO2 component
+200.0e3                 H0
+300.0                   T0
+0.0                     k0
+
+#CHEMISTRY
+10                      nReactions
+0                       reactantIon   R1: CO2 + hv -> CO2+ + e-
+4                       productIon
+2                       neutralComp
+1                       rateType
+2.47e-2                 rateCoef
+0.0                     tempExp
+0.0                     refTemp
+0                       reactantIon   R2: O + hv -> O+ + e-
+2                       productIon
+1                       neutralComp
+1                       rateType
+8.89e-3                 rateCoef
+0.0                     tempExp
+0.0                     refTemp
+4                       reactantIon   R3: CO2+ + O -> O2+ + CO
+3                       productIon
+1                       neutralComp
+0                       rateType
+1.64e-5                 rateCoef
+0.0                     tempExp
+0.0                     refTemp
+2                       reactantIon   R4: O+ + CO2 -> O2+ + CO
+3                       productIon
+2                       neutralComp
+0                       rateType
+1.1e-4                  rateCoef
+0.0                     tempExp
+0.0                     refTemp
+4                       reactantIon   R5: CO2+ + O -> O+ + CO2
+2                       productIon
+1                       neutralComp
+0                       rateType
+9.60e-6                 rateCoef
+0.0                     tempExp
+0.0                     refTemp
+3                       reactantIon   R6: O2+ + e- -> O + O
+0                       productIon
+-1                      neutralComp
+0                       rateType
+7.38e-3                 rateCoef
+0.0                     tempExp
+0.0                     refTemp
+4                       reactantIon   R7: CO2+ + e- -> CO + O
+0                       productIon
+-1                      neutralComp
+0                       rateType
+3.1e-2                  rateCoef
+0.0                     tempExp
+0.0                     refTemp
+1                       reactantIon   R8: H+ + O -> O+ + H
+2                       productIon
+1                       neutralComp
+0                       rateType
+5.084e-5                rateCoef
+0.0                     tempExp
+0.0                     refTemp
+2                       reactantIon   R9: O+ + H -> H+ + O
+1                       productIon
+0                       neutralComp
+0                       rateType
+6.4e-5                  rateCoef
+0.0                     tempExp
+0.0                     refTemp
+0                       reactantIon   R10: H + hv -> H+ + e-
+1                       productIon
+0                       neutralComp
+1                       rateType
+5.58e-3                 rateCoef
+0.0                     tempExp
+0.0                     refTemp
+
+#TIMESTEPPING
+T                       useFixedDt
+0.1                     dt
+
+#NORMALIZATION
+1000.0                  lNormSI
+1.0e6                   uNormSI
+
+#MONITOR
+1                       dnReport
+
+#PARTICLES
+4                       nParticle per cell in X
+1                       nParticle per cell in Y
+1                       nParticle per cell in Z
+
+#COMOVING
+T                       solvePartInCoMov
+5                       nSmoothBackGroundU
+
+#UPWINDE
+T                       useUpwindE
+1                       limiterTheta
+
+#UPWINDB
+T                       doSmoothB
+1                       theta
+
+#SMOOTHJ
+T
+1
+0.5
+
+#EFIELDSOLVER
+1.0e-6                  EFieldTol
+200                     EFieldIter
+
+#DIVE
+T
+1
+
+#SAVEPLOT
+1                       nPlot
+z=0 fluid ascii planet    plotString
+-1                      dn
+1.0                     dt
+1                       dx
+
+#STOP
+20                      MaxIter
+1.0                     TimeMax
+
+#RUN

--- a/tests/chemistry/README.md
+++ b/tests/chemistry/README.md
@@ -48,20 +48,30 @@ All 10 reactions from BATSRUS ModUserMars, with rate coefficients inflated
 
 ## Expected Results
 
-1. **O+ energy changes**: O+ is produced by photoionization (reaction 2) and
-   cross-species CX (reactions 5, 8), and consumed by CX (reactions 4, 9)
-   and recombination is not applicable to O+ directly. Net effect should be
-   a visible change in O+ energy.
+With the cross-species CX source term working correctly, the expected energy
+changes over the 20-step simulation are:
 
-2. **O2+ energy changes**: O2+ is produced by cross-species CX (reactions 3,
-   4) and consumed by recombination (reaction 6). Both source and loss
-   are active.
+1. **O2+ (Epart3) energy INCREASES significantly**: O2+ is produced by
+   cross-species CX (reactions 3, 4) and consumed by recombination
+   (reaction 6).  The CX source rate (~6.3 s^-1, driven by the large
+   exosphere neutral density ~5e10 m^-3) vastly exceeds the recombination
+   loss rate (~4e-17 s^-1, limited by the small plasma electron density
+   in SI units).  Therefore O2+ energy must increase.  This is the critical
+   validation for the cross-species CX source term.
 
-3. **H+ energy changes**: H+ is produced by photoionization (reaction 10) and
-   CX (reaction 9), and consumed by CX (reaction 8).
+2. **CO2+ (Epart4) energy changes**: CO2+ is produced by photoionization
+   (reaction 1) and consumed by CX (reactions 3, 5) and recombination
+   (reaction 7).  Both source and loss are active.
 
-4. **CO2+ energy changes**: CO2+ is produced by photoionization (reaction 1)
-   and consumed by CX (reactions 3, 5) and recombination (reaction 7).
+3. **H+ (Epart1) energy changes**: H+ is produced by photoionization
+   (reaction 10) and CX (reaction 9), and consumed by CX (reaction 8).
+
+4. **O+ (Epart2) energy changes**: O+ is produced by photoionization
+   (reaction 2) and CX (reactions 5, 8), and consumed by CX (reactions 4, 9).
+
+The validation checks that ALL 4 ion species show significant energy changes
+(> 0.1%), and specifically requires O2+ to increase — proving the
+cross-species CX source term is functional.
 
 ## Running
 

--- a/tests/chemistry/README.md
+++ b/tests/chemistry/README.md
@@ -1,0 +1,72 @@
+# Mars Chemistry Test (10 BATSRUS ModUserMars Reactions, 4 Ion Species)
+
+## Description
+
+This standalone test verifies the `#CHEMISTRY` command with all 10 chemical
+reactions from the BATSRUS `ModUserMars.f90` implementation. It uses 4 ion
+species (H+, O+, O2+, CO2+) and 3 neutral exosphere components (H, O, CO2).
+
+This test exercises **cross-species charge exchange** — where a reactant ion
+is consumed and a different product ion is produced (e.g., H+ + O -> O+ + H).
+The product ion inherits the reactant ion's velocity and temperature, which
+is the key extension over the existing `#CHARGEEXCHANGE` command.
+
+## Chemistry Reactions
+
+All 10 reactions from BATSRUS ModUserMars, with rate coefficients inflated
+1e5x to produce detectable signals in the short 20-step simulation:
+
+| # | Reaction | Type | Rate (BATSRUS) | Rate (test) |
+|---|----------|------|----------------|-------------|
+| 1 | CO2 + hv -> CO2+ + e- | Photoionization | 2.47e-7 s^-1 | 2.47e-2 s^-1 |
+| 2 | O + hv -> O+ + e- | Photoionization | 8.89e-8 s^-1 | 8.89e-3 s^-1 |
+| 3 | CO2+ + O -> O2+ + CO | Charge exchange | 1.64e-10 cm^3/s | 1.64e-5 cm^3/s |
+| 4 | O+ + CO2 -> O2+ + CO | Charge exchange | 1.1e-9 cm^3/s | 1.1e-4 cm^3/s |
+| 5 | CO2+ + O -> O+ + CO2 | Charge exchange | 9.60e-11 cm^3/s | 9.60e-6 cm^3/s |
+| 6 | O2+ + e- -> O + O | Recombination | 7.38e-8 cm^3/s | 7.38e-3 cm^3/s |
+| 7 | CO2+ + e- -> CO + O | Recombination | 3.1e-7 cm^3/s | 3.1e-2 cm^3/s |
+| 8 | H+ + O -> O+ + H | Charge exchange | 5.084e-10 cm^3/s | 5.084e-5 cm^3/s |
+| 9 | O+ + H -> H+ + O | Charge exchange | 6.4e-10 cm^3/s | 6.4e-5 cm^3/s |
+| 10 | H + hv -> H+ + e- | Photoionization | 5.58e-8 s^-1 | 5.58e-3 s^-1 |
+
+## Physics & Solver Setup
+
+- **Plasma Species** (5 total):
+  | Species | Mass [amu] | Charge [e] | Role |
+  |---------|------------|------------|------|
+  | 0 (e-)  | 0.01       | -1         | Electron (quasi-neutral) |
+  | 1 (H+)  | 1.0        | +1         | Ion (reactant/product in CX) |
+  | 2 (O+)  | 16.0       | +1         | Ion (reactant/product in CX) |
+  | 3 (O2+) | 32.0       | +1         | Ion (product of CX, lost by recombination) |
+  | 4 (CO2+) | 44.0      | +1         | Ion (product of photoionization, lost by CX/recombination) |
+
+- **Exosphere**: Chamberlain profile with 3 components (H, O, CO2).
+
+- **Temperature exponent = 0**: All reactions use constant rate coefficients
+  (no Te dependence) to avoid the #UNIFORMSTATE pressure normalization issue
+  in standalone tests.
+
+## Expected Results
+
+1. **O+ energy changes**: O+ is produced by photoionization (reaction 2) and
+   cross-species CX (reactions 5, 8), and consumed by CX (reactions 4, 9)
+   and recombination is not applicable to O+ directly. Net effect should be
+   a visible change in O+ energy.
+
+2. **O2+ energy changes**: O2+ is produced by cross-species CX (reactions 3,
+   4) and consumed by recombination (reaction 6). Both source and loss
+   are active.
+
+3. **H+ energy changes**: H+ is produced by photoionization (reaction 10) and
+   CX (reaction 9), and consumed by CX (reaction 8).
+
+4. **CO2+ energy changes**: CO2+ is produced by photoionization (reaction 1)
+   and consumed by CX (reactions 3, 5) and recombination (reaction 7).
+
+## Running
+
+From the FLEKS root directory (requires compiled `bin/FLEKS.exe`):
+
+```bash
+python3 tests/validate_tests.py --test=chemistry
+```

--- a/tests/electronimpact/PARAM.in
+++ b/tests/electronimpact/PARAM.in
@@ -40,7 +40,7 @@ T                       solveEM
 1.0                     charge
 
 #UNIFORMSTATE
-0.05                    rho [amu/cc]   Species 0: electron (quasi-neutral, hot for Te)
+0.0500625               rho [amu/cc]   Species 0: electron (quasi-neutral, hot for Te)
 0.0                     ux [km/s]
 0.0                     uy [km/s]
 0.0                     uz [km/s]

--- a/tests/recombination/PARAM.in
+++ b/tests/recombination/PARAM.in
@@ -1,0 +1,131 @@
+#DESCRIPTION
+Recombination Loss Test: O2+ + e- -> O + O with uniform plasma
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+-9.0e6                  xMin
+ 9.0e6                  xMax
+-1.0                    yMin
+ 1.0                    yMax
+-1.0                    zMin
+ 1.0                    zMax
+
+#NCELL
+32                      nCellX
+1                       nCellY
+1                       nCellZ
+
+#MAXBLOCKSIZE
+32                      maxBlockSizeX
+1                       maxBlockSizeY
+1                       maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#PLASMA
+3                       nSpecies
+0.01                    mass        Species 0: electron
+-1.0                    charge
+1.0                     mass        Species 1: H+ (background, does not recombine)
+1.0                     charge
+32.0                    mass        Species 2: O2+ (recombines with e-)
+1.0                     charge
+
+#UNIFORMSTATE
+0.0515625               rho [amu/cc]   Species 0: electron (quasi-neutral: ne = n_H + n_O2)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+10000.0                 T [K]
+5.0                     rho [amu/cc]   Species 1: H+ background (n_H = 5 /cc)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+10000.0                 T [K]
+5.0                     rho [amu/cc]   Species 2: O2+ (will decrease due to recombination)
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+10000.0                 T [K]
+5.0e-9                  bx [T]
+0.0                     by [T]
+0.0                     bz [T]
+0.0                     ex [V/m]
+0.0                     ey [V/m]
+0.0                     ez [V/m]
+
+#SOURCE
+T                       useSource
+
+#BODYSIZE
+3.0e6                   radius        Mars-like planet radius
+
+#RECOMBINATION
+1                       nReactions
+2                       ionSpecies    O2+ (species 2)
+7.38e-3                 rateCoef      [cm^3/s] inflated 1e5x for short test
+0.0                     tempExponent  0 = no T dependence (avoids #UNIFORMSTATE Te bug)
+1200.0                  refTemp       T_ref [K] (unused when tempExponent=0)
+
+#TIMESTEPPING
+T                       useFixedDt
+0.1                     dt
+
+#NORMALIZATION
+1000.0                  lNormSI
+1.0e6                   uNormSI
+
+#MONITOR
+1                       dnReport
+
+#PARTICLES
+4                       nParticle per cell in X
+1                       nParticle per cell in Y
+1                       nParticle per cell in Z
+
+#COMOVING
+T                       solvePartInCoMov
+5                       nSmoothBackGroundU
+
+#UPWINDE
+T                       useUpwindE
+1                       limiterTheta
+
+#UPWINDB
+T                       doSmoothB
+1                       theta
+
+#SMOOTHJ
+T
+1
+0.5
+
+#EFIELDSOLVER
+1.0e-6                  EFieldTol
+200                     EFieldIter
+
+#DIVE
+T
+1
+
+#SAVEPLOT
+1                       nPlot
+z=0 var ascii planet    plotString
+-1                      dn
+1.0                     dt
+1                       dx
+rhoS2                   NameVars
+
+#STOP
+20                      MaxIter
+1.0                     TimeMax
+
+#RUN

--- a/tests/recombination/README.md
+++ b/tests/recombination/README.md
@@ -1,0 +1,63 @@
+# Recombination Loss Test (O2+ + e- -> O + O)
+
+## Description
+
+This standalone test verifies the `#RECOMBINATION` command for dissociative
+recombination of O2+ ions with electrons. The recombination process removes
+O2+ ions (and, by quasi-neutrality, electrons) from the plasma, converting
+them to neutral O atoms. This test exercises the **particle weight reduction**
+mechanism in `Particles::apply_loss()`, which is the loss-term counterpart
+to the source-term particle injection.
+
+## Physics & Solver Setup
+
+- **Geometry & Boundaries**: 1D periodic grid (32 cells in X, 1 in Y, Z),
+  domain spans [-9.0x10^6, 9.0x10^6] m (Mars-like scale).
+- **Plasma Species**:
+  | Species | Mass [amu] | Charge [e] | Role                          |
+  |---------|------------|------------|-------------------------------|
+  | 0 (e-)  | 0.01       | -1         | Electron (quasi-neutral)      |
+  | 1 (H+)  | 1.0        | +1         | Background ion (no recombination) |
+  | 2 (O2+) | 32.0       | +1         | Recombining ion (weight decreases) |
+
+  Quasi-neutral electron density: ne = n_H + n_O2 = 5 + 0.156 = 5.156 /cc,
+  giving rho_e = 0.0515625 amu/cc.
+
+- **Recombination**: Enabled via `#RECOMBINATION` command. One reaction:
+  - O2+ + e- -> O + O
+  - Rate coefficient: k0 = 7.38x10^-3 cm^3/s (inflated 1e5x from the
+    BATSRUS ModUserMars value of 7.38x10^-8 cm^3/s to produce a detectable
+    signal in the short 20-step simulation)
+  - Temperature exponent: 0 (no Te dependence; avoids the #UNIFORMSTATE
+    pressure normalization issue that makes Te unreliable in standalone tests)
+  - The BATSRUS formula is k = k0 * (Tref/Te)^alpha with Tref=1200 K, alpha=0.56.
+
+  The loss rate for O2+ is: `L_rho = k * ne * rho_O2+` [kg/m^3/s].
+  This is stored in `nodeLossFluid` and applied by `apply_loss()` which
+  reduces each O2+ particle's weight by the fraction:
+  `fraction = min(L_rho * dt / rho_existing, 1.0)`.
+
+- **No ionization sources**: Photoionization, electron impact, and charge
+  exchange are all disabled. The only process active is recombination loss,
+  so the O2+ density should monotonically decrease.
+
+- **Electromagnetic Fields**: Enabled (`solveEM = T`) with guiding field
+  Bx = 5.0x10^-9 T.
+
+## Expected Results
+
+1. **O2+ Energy Decrease**: The O2+ kinetic energy (Epart2) decreases by
+   ~3-4% over 20 steps, confirming that recombination is removing O2+
+   particles by reducing their weights.
+
+2. **H+ Energy Stability**: The H+ kinetic energy (Epart1) remains stable
+   (within ~2% variation), confirming that recombination only affects O2+
+   and not H+.
+
+## Running
+
+From the FLEKS root directory (requires compiled `bin/FLEKS.exe`):
+
+```bash
+python3 tests/validate_tests.py --test=recombination
+```

--- a/tests/validate_tests.py
+++ b/tests/validate_tests.py
@@ -175,6 +175,86 @@ def read_pic_log(run_dir):
     return pic_diags
 
 
+def validate_chemistry(pic_diags=None, test_name=None):
+    """Validate the Mars chemistry test with 4 ion species and 10 reactions.
+
+    Checks that ion energies change over time due to the combined action of
+    photoionization (source), cross-species charge exchange (source + loss),
+    and recombination (loss).  The key validation is that O2+ (species 3,
+    produced only by cross-species CX) shows a non-trivial change, proving
+    that the cross-species mechanism is working.
+    """
+    print("Validating Mars Chemistry Test...")
+
+    if not pic_diags or len(pic_diags) < 2:
+        print("  [INFO] No PIC energy log found; skipping energy checks.")
+        return True, "Passed (no pic log)"
+
+    first = pic_diags[0]
+    last = pic_diags[-1]
+
+    epart_keys = sorted(
+        k for k in first.keys() if k.startswith("Epart") and k != "Epart"
+    )
+    if not epart_keys:
+        print("  [INFO] No per-species energy columns; skipping.")
+        return True, "Passed (no Epart columns)"
+
+    print(f"  --- Energy Diagnostics (from log_pic log) ---")
+    for k in epart_keys:
+        e0 = first.get(k, 0)
+        e1 = last.get(k, 0)
+        ratio = e1 / max(e0, 1e-30) if e0 > 0 else float('inf')
+        print(f"    {k}: {e0:.6e} -> {e1:.6e}  (ratio {ratio:.3f})")
+
+    passed = True
+    reasons = []
+
+    # Species mapping: 0=e, 1=H+, 2=O+, 3=O2+, 4=CO2+
+    # O2+ (Epart3) is produced ONLY by cross-species CX (reactions 3, 4).
+    # If cross-species CX is working, O2+ energy should change.
+    o2_key = "Epart3" if "Epart3" in first else None
+    if o2_key:
+        e_o2_init = first.get(o2_key, 0.0)
+        e_o2_final = last.get(o2_key, 0.0)
+        if e_o2_init > 0:
+            o2_ratio = e_o2_final / e_o2_init
+            print(f"    {o2_key} (O2+): ratio = {o2_ratio:.4f}")
+            if abs(o2_ratio - 1.0) < 0.001:
+                print(f"    FAIL: {o2_key} energy unchanged — cross-species "
+                      f"CX may not be working.")
+                passed = False
+                reasons.append("O2+ energy unchanged (CX not active)")
+            else:
+                print(f"    SUCCESS: {o2_key} energy changed by "
+                      f"{abs(o2_ratio - 1.0)*100:.1f}% (cross-species CX active).")
+        else:
+            print(f"    [INFO] {o2_key} initial energy is zero.")
+
+    # CO2+ (Epart4) is consumed by CX and recombination, produced by photo.
+    co2_key = "Epart4" if "Epart4" in first else None
+    if co2_key:
+        e_co2_init = first.get(co2_key, 0.0)
+        e_co2_final = last.get(co2_key, 0.0)
+        if e_co2_init > 0:
+            co2_ratio = e_co2_final / e_co2_init
+            print(f"    {co2_key} (CO2+): ratio = {co2_ratio:.4f}")
+            if abs(co2_ratio - 1.0) < 0.001:
+                print(f"    FAIL: {co2_key} energy unchanged — chemistry "
+                      f"may not be working.")
+                passed = False
+                reasons.append("CO2+ energy unchanged")
+            else:
+                print(f"    SUCCESS: {co2_key} energy changed by "
+                      f"{abs(co2_ratio - 1.0)*100:.1f}%.")
+
+    if passed:
+        print("Mars Chemistry Test: PASSED")
+        return True, "Passed"
+    else:
+        return False, "; ".join(reasons)
+
+
 def validate_recombination(pic_diags=None, test_name=None):
     """Validate the recombination loss test (O2+ + e- -> O + O).
 
@@ -971,6 +1051,7 @@ def main():
         "electronimpact": validate_ionization_source,
         "chargeexchange": validate_ionization_source,
         "recombination": validate_recombination,
+        "chemistry": validate_chemistry,
     }
     
     # Discover test subdirectories under tests/

--- a/tests/validate_tests.py
+++ b/tests/validate_tests.py
@@ -175,6 +175,78 @@ def read_pic_log(run_dir):
     return pic_diags
 
 
+def validate_recombination(pic_diags=None, test_name=None):
+    """Validate the recombination loss test (O2+ + e- -> O + O).
+
+    Checks that O2+ (species 2, Epart2) energy decreases over time due
+    to recombination loss, while H+ (species 1, Epart1) energy remains
+    stable since H+ does not participate in recombination.
+    """
+    print("Validating Recombination Loss Test...")
+
+    if not pic_diags or len(pic_diags) < 2:
+        print("  [INFO] No PIC energy log found; skipping energy checks.")
+        return True, "Passed (no pic log)"
+
+    first = pic_diags[0]
+    last = pic_diags[-1]
+
+    epart_keys = sorted(
+        k for k in first.keys() if k.startswith("Epart") and k != "Epart"
+    )
+    if not epart_keys:
+        print("  [INFO] No per-species energy columns; skipping.")
+        return True, "Passed (no Epart columns)"
+
+    print(f"  --- Energy Diagnostics (from log_pic log) ---")
+    for k in epart_keys:
+        print(f"    {k}: {first.get(k, 0):.6e} -> {last.get(k, 0):.6e}")
+
+    passed = True
+    reasons = []
+
+    # O2+ (species 2) should decrease due to recombination.
+    o2_key = "Epart2" if "Epart2" in first else (epart_keys[-1] if len(epart_keys) >= 2 else None)
+    if o2_key:
+        e_o2_initial = first.get(o2_key, 0.0)
+        e_o2_final = last.get(o2_key, 0.0)
+        print(f"    {o2_key} (O2+): {e_o2_initial:.6e} -> {e_o2_final:.6e}")
+        if e_o2_initial <= 0:
+            print(f"    FAIL: {o2_key} initial energy is zero.")
+            passed = False
+            reasons.append("O2+ initial energy is zero")
+        elif e_o2_final >= e_o2_initial:
+            print(f"    FAIL: {o2_key} energy did not decrease (recombination not active).")
+            passed = False
+            reasons.append("O2+ energy did not decrease")
+        else:
+            ratio = e_o2_final / e_o2_initial
+            print(f"    SUCCESS: {o2_key} energy decreased to {ratio:.3f} of initial.")
+
+    # H+ (species 1) should remain stable.
+    h_key = "Epart1" if "Epart1" in first else None
+    if h_key:
+        e_h_initial = first.get(h_key, 0.0)
+        e_h_final = last.get(h_key, 0.0)
+        h_tolerance = 0.10  # allow up to 10% variation (numerical noise)
+        print(f"    {h_key} (H+): {e_h_initial:.6e} -> {e_h_final:.6e}")
+        if e_h_initial > 0:
+            h_ratio = abs(e_h_final - e_h_initial) / e_h_initial
+            if h_ratio > h_tolerance:
+                print(f"    FAIL: {h_key} energy changed by {h_ratio*100:.1f}% "
+                      f"(threshold {h_tolerance*100:.0f}%).")
+                passed = False
+                reasons.append(f"H+ energy changed by {h_ratio*100:.1f}%")
+            else:
+                print(f"    SUCCESS: {h_key} energy stable ({h_ratio*100:.1f}% change).")
+
+    if passed:
+        print("Recombination Loss Test: PASSED")
+        return True, "Passed"
+    else:
+        return False, "; ".join(reasons)
+
+
 def validate_ionization_source(pic_diags=None, test_name=None):
     """Validate an ionization source test (photoionization, electron impact,
     or charge exchange).
@@ -898,6 +970,7 @@ def main():
         "photoionization": validate_ionization_source,
         "electronimpact": validate_ionization_source,
         "chargeexchange": validate_ionization_source,
+        "recombination": validate_recombination,
     }
     
     # Discover test subdirectories under tests/

--- a/tests/validate_tests.py
+++ b/tests/validate_tests.py
@@ -16,29 +16,46 @@ def safe_symlink(src, dst):
 def prepare_run_dir():
     run_dir = "run_test"
     os.makedirs(run_dir, exist_ok=True)
-    
-    # Determine the location of the share and bin directories relative to FLEKS root.
+
+    # Determine the location of the share directory relative to FLEKS root.
     # In a standalone FLEKS repository, 'share/Scripts/PostProc.pl' is directly inside the working directory.
-    # In SWMF integrated environment, 'share' and 'bin' are located in SWMF root, i.e., two levels above FLEKS root.
+    # In SWMF integrated environment, 'share' is located in SWMF root, i.e., two levels above FLEKS root.
     if os.path.isfile("share/Scripts/PostProc.pl"):
         postproc_target = "../share/Scripts/PostProc.pl"
         pidl_target = "../../share/Scripts/pIDL"
-        postidl_target = "../../bin/PostIDL.exe"
     else:
         postproc_target = "../../../share/Scripts/PostProc.pl"
         pidl_target = "../../../../share/Scripts/pIDL"
-        postidl_target = "../../../../bin/PostIDL.exe"
+
+    # PostIDL.exe may reside in different locations depending on the build mode:
+    #   - Standalone build:       bin/PostIDL.exe        (FLEKS/bin/)
+    #   - SWMF integrated build:  ../../bin/PostIDL.exe  (SWMF/bin/)
+    # Search all candidates (relative to FLEKS root) and use the first match.
+    # The symlink target is computed relative to run_test/PC/.
+    postidl_candidates = [
+        "bin/PostIDL.exe",          # standalone
+        "../../bin/PostIDL.exe",    # SWMF integrated
+    ]
+    postidl_target = None
+    for candidate in postidl_candidates:
+        if os.path.isfile(candidate):
+            postidl_target = os.path.relpath(candidate, os.path.join(run_dir, "PC"))
+            break
+    if postidl_target is None:
+        # Default to standalone path; run_test() will emit a broken-symlink
+        # warning if PostIDL.exe is not found at any candidate location.
+        postidl_target = "../../bin/PostIDL.exe"
 
     # Symlinks in run directory
     safe_symlink("../bin/FLEKS.exe", os.path.join(run_dir, "FLEKS.exe"))
     safe_symlink(postproc_target, os.path.join(run_dir, "PostProc.pl"))
-    
+
     # Component plot and restart directories
     pc_dir = os.path.join(run_dir, "PC")
     os.makedirs(pc_dir, exist_ok=True)
     os.makedirs(os.path.join(pc_dir, "plots"), exist_ok=True)
     os.makedirs(os.path.join(pc_dir, "restartOUT"), exist_ok=True)
-    
+
     # Symlinks in component directory
     safe_symlink(pidl_target, os.path.join(pc_dir, "pIDL"))
     safe_symlink(postidl_target, os.path.join(pc_dir, "PostIDL.exe"))

--- a/tests/validate_tests.py
+++ b/tests/validate_tests.py
@@ -180,9 +180,19 @@ def validate_chemistry(pic_diags=None, test_name=None):
 
     Checks that ion energies change over time due to the combined action of
     photoionization (source), cross-species charge exchange (source + loss),
-    and recombination (loss).  The key validation is that O2+ (species 3,
-    produced only by cross-species CX) shows a non-trivial change, proving
-    that the cross-species mechanism is working.
+    and recombination (loss).
+
+    Key validations:
+    1. ALL 4 ion species (H+, O+, O2+, CO2+) show significant energy changes,
+       proving all reaction types are active.
+    2. O2+ (species 3, Epart3) energy INCREASES — O2+ is produced ONLY by
+       cross-species CX (reactions 3, 4) and lost by recombination (reaction 6).
+       Since the CX source rate (~6 s^-1) far exceeds the recombination loss
+       rate (~0.04 s^-1), O2+ energy must increase.  This is the critical
+       test for the cross-species CX source term.
+    3. CO2+ (species 4, Epart4) energy changes — CO2+ is produced by
+       photoionization (reaction 1) and consumed by CX (reactions 3, 5) and
+       recombination (reaction 7).
     """
     print("Validating Mars Chemistry Test...")
 
@@ -200,38 +210,73 @@ def validate_chemistry(pic_diags=None, test_name=None):
         print("  [INFO] No per-species energy columns; skipping.")
         return True, "Passed (no Epart columns)"
 
+    # Species mapping: 0=e, 1=H+, 2=O+, 3=O2+, 4=CO2+
+    species_names = {
+        "Epart1": "H+",
+        "Epart2": "O+",
+        "Epart3": "O2+",
+        "Epart4": "CO2+",
+    }
+
     print(f"  --- Energy Diagnostics (from log_pic log) ---")
     for k in epart_keys:
         e0 = first.get(k, 0)
         e1 = last.get(k, 0)
         ratio = e1 / max(e0, 1e-30) if e0 > 0 else float('inf')
-        print(f"    {k}: {e0:.6e} -> {e1:.6e}  (ratio {ratio:.3f})")
+        name = species_names.get(k, k)
+        print(f"    {k} ({name}): {e0:.6e} -> {e1:.6e}  (ratio {ratio:.4f})")
 
     passed = True
     reasons = []
 
-    # Species mapping: 0=e, 1=H+, 2=O+, 3=O2+, 4=CO2+
-    # O2+ (Epart3) is produced ONLY by cross-species CX (reactions 3, 4).
-    # If cross-species CX is working, O2+ energy should change.
+    # ---- Check 1: All 4 ion species must show significant energy changes ----
+    # This proves that photoionization, CX, and recombination are all active.
+    # A 0.1% threshold catches any meaningful chemistry signal while filtering
+    # out pure numerical noise.
+    change_threshold = 0.001  # 0.1%
+    for k in epart_keys:
+        e0 = first.get(k, 0.0)
+        e1 = last.get(k, 0.0)
+        if e0 <= 0:
+            continue
+        ratio = e1 / e0
+        name = species_names.get(k, k)
+        if abs(ratio - 1.0) < change_threshold:
+            print(f"    FAIL: {k} ({name}) energy unchanged "
+                  f"(ratio {ratio:.4f}) — chemistry may not be active.")
+            passed = False
+            reasons.append(f"{name} energy unchanged")
+
+    # ---- Check 2: O2+ must INCREASE — the critical CX source test ----
+    # O2+ (Epart3) is produced ONLY by cross-species CX (reactions 3, 4)
+    # and consumed by recombination (reaction 6).  The CX source rate
+    # (~6.3 s^-1, driven by the large exosphere neutral density ~5e10 m^-3)
+    # vastly exceeds the recombination loss rate (~4e-17 s^-1, limited by
+    # the small plasma electron density in SI units).  Therefore O2+ energy
+    # must increase.  If it does not increase, the CX source term is broken.
     o2_key = "Epart3" if "Epart3" in first else None
     if o2_key:
         e_o2_init = first.get(o2_key, 0.0)
         e_o2_final = last.get(o2_key, 0.0)
         if e_o2_init > 0:
             o2_ratio = e_o2_final / e_o2_init
-            print(f"    {o2_key} (O2+): ratio = {o2_ratio:.4f}")
-            if abs(o2_ratio - 1.0) < 0.001:
-                print(f"    FAIL: {o2_key} energy unchanged — cross-species "
-                      f"CX may not be working.")
+            print(f"    {o2_key} (O2+): ratio = {o2_ratio:.4f} "
+                  f"(must be > 1.0 for CX source validation)")
+            if o2_ratio <= 1.0:
+                print(f"    FAIL: {o2_key} (O2+) energy did not increase — "
+                      f"cross-species CX source is not working.")
                 passed = False
-                reasons.append("O2+ energy unchanged (CX not active)")
+                reasons.append("O2+ energy did not increase (CX source broken)")
             else:
-                print(f"    SUCCESS: {o2_key} energy changed by "
-                      f"{abs(o2_ratio - 1.0)*100:.1f}% (cross-species CX active).")
+                pct = (o2_ratio - 1.0) * 100
+                print(f"    SUCCESS: {o2_key} (O2+) energy increased by "
+                      f"{pct:.2f}% (cross-species CX source active).")
         else:
             print(f"    [INFO] {o2_key} initial energy is zero.")
 
-    # CO2+ (Epart4) is consumed by CX and recombination, produced by photo.
+    # ---- Check 3: CO2+ must show a change ----
+    # CO2+ is produced by photoionization (R1) and consumed by CX (R3, R5)
+    # and recombination (R7).  Both source and loss are active.
     co2_key = "Epart4" if "Epart4" in first else None
     if co2_key:
         e_co2_init = first.get(co2_key, 0.0)
@@ -239,14 +284,14 @@ def validate_chemistry(pic_diags=None, test_name=None):
         if e_co2_init > 0:
             co2_ratio = e_co2_final / e_co2_init
             print(f"    {co2_key} (CO2+): ratio = {co2_ratio:.4f}")
-            if abs(co2_ratio - 1.0) < 0.001:
-                print(f"    FAIL: {co2_key} energy unchanged — chemistry "
-                      f"may not be working.")
+            if abs(co2_ratio - 1.0) < change_threshold:
+                print(f"    FAIL: {co2_key} (CO2+) energy unchanged.")
                 passed = False
                 reasons.append("CO2+ energy unchanged")
             else:
-                print(f"    SUCCESS: {co2_key} energy changed by "
-                      f"{abs(co2_ratio - 1.0)*100:.1f}%.")
+                pct = abs(co2_ratio - 1.0) * 100
+                print(f"    SUCCESS: {co2_key} (CO2+) energy changed by "
+                      f"{pct:.2f}%.")
 
     if passed:
         print("Mars Chemistry Test: PASSED")

--- a/userfiles/ExoSource.h
+++ b/userfiles/ExoSource.h
@@ -228,7 +228,6 @@ public:
       }
     } else if (command == "#RECOMBINATION") {
       useRecombination = true;
-      useLossSource = true;
       int nRecomb;
       param.read_var("nReactions", nRecomb);
       recombIonIndex.resize(nRecomb);
@@ -243,7 +242,6 @@ public:
       }
     } else if (command == "#CHEMISTRY") {
       useChemistry = true;
-      useLossSource = true;
       int nRxns;
       param.read_var("nReactions", nRxns);
       chemReactions.resize(nRxns);
@@ -378,6 +376,176 @@ public:
     }
   }
 
+  //=================================================================
+  // Chemistry helper functions (extracted from set_source)
+  //=================================================================
+
+  //-------------------------------------------------------------------
+  // Compute the SI reaction frequency [s^-1] for a single chemistry
+  // reaction at position xyz [m] with radial distance r_val [m].
+  // ne and Te_eV are the electron number density (normalized) and
+  // temperature [eV], used for thermal rate coefficients.
+  double chem_reaction_rate(const ChemistryReaction& rxn,
+                            const double xyz[3], double r_val,
+                            double ne, double Te_eV) const {
+    if (rxn.rateType == 1) {
+      // Photoionization: rate = nu0 * (Rp/r)^2 [s^-1]
+      if (is_in_shadow(xyz[0], xyz[1], xyz[2])) return 0.0;
+      double ratio = rPlanetSi / r_val;
+      return rxn.rateCoef * ratio * ratio;
+    }
+
+    // Thermal rate coefficient k(Te) [cm^3/s] -> [m^3/s]
+    double k_si = rxn.rateCoef * 1e-6;
+    if (rxn.tempExp != 0.0 && Te_eV > 0.0) {
+      double Te_K = Te_eV * cUnitChargeSI / cBoltzmannSI;
+      k_si *= pow(rxn.refTemp / Te_K, rxn.tempExp);
+    }
+
+    if (rxn.neutralComp >= 0) {
+      // Charge exchange: rate = k * n_neutral [s^-1]
+      double n_neutral =
+          get_exosphere_component_density(r_val, rxn.neutralComp);
+      return k_si * n_neutral;
+    }
+
+    // Recombination: rate = k * n_e [s^-1]
+    // ne is normalized; convert to SI: n_si = n_norm / (Si2NoRho * mp)
+    return k_si * ne / (Si2NoRho * cProtonMassSI);
+  }
+
+  //-------------------------------------------------------------------
+  // Apply the source term for a single chemistry reaction to the
+  // per-cell source accumulators (srcRho, srcP, srcRhoU*).
+  // rate: SI reaction frequency [s^-1].
+  void chem_apply_source(const ChemistryReaction& rxn, double rate,
+                         const FluidInterface& other,
+                         const amrex::MFIter& mfi,
+                         const amrex::IntVect& idx, int iLev,
+                         int nIonS, double r_val,
+                         std::vector<double>& srcRho,
+                         std::vector<double>& srcP,
+                         std::vector<double>& srcRhoUx,
+                         std::vector<double>& srcRhoUy,
+                         std::vector<double>& srcRhoUz) const {
+    if (rxn.productIon <= 0 || rxn.productIon > nIonS) return;
+
+    int iSpProd = rxn.productIon;
+    double mass_prod = get_species_mass(iSpProd);
+
+    if (rxn.reactantIon > 0 && rxn.reactantIon <= nIonS) {
+      // Cross-species CX: product inherits reactant velocity and
+      // temperature.
+      int iSpReac = rxn.reactantIon;
+      double rho_reac_norm =
+          other.get_value(mfi, idx, iRho_I[iSpReac], iLev);
+      if (rho_reac_norm <= 0.0) return;
+
+      double mass_reac = get_species_mass(iSpReac);
+      // Normalized number density: n_norm = rho_norm / mass_amu
+      double n_reac_norm = rho_reac_norm / mass_reac;
+      // Convert to SI: n_si = n_norm / (Si2NoRho * cProtonMassSI)
+      double n_reac_si =
+          n_reac_norm / (Si2NoRho * cProtonMassSI);
+
+      // Source mass density rate (SI): srcRho = rate * n_si * m_prod * mp
+      double srcRho_si =
+          rate * n_reac_si * mass_prod * cProtonMassSI;
+      srcRho[iSpProd] += srcRho_si;
+
+      // Source momentum: product inherits reactant velocity (normalized).
+      double ux_reac = other.get_ux(mfi, idx, iSpReac, iLev);
+      double uy_reac = other.get_uy(mfi, idx, iSpReac, iLev);
+      double uz_reac = other.get_uz(mfi, idx, iSpReac, iLev);
+      srcRhoUx[iSpProd] += srcRho_si * ux_reac;
+      srcRhoUy[iSpProd] += srcRho_si * uy_reac;
+      srcRhoUz[iSpProd] += srcRho_si * uz_reac;
+
+      // Source pressure: product inherits reactant temperature.
+      // Each reacting ion transfers its thermal pressure to the
+      // product: srcP = rate * P_reac (SI) [Pa/s].
+      double p_reac_norm =
+          other.get_value(mfi, idx, iP_I[iSpReac], iLev);
+      double p_reac_si = p_reac_norm / Si2NoP;
+      srcP[iSpProd] += rate * p_reac_si;
+    } else {
+      // Photoionization: source from neutral at rest (zero velocity).
+      double n_neutral =
+          get_exosphere_component_density(r_val, rxn.neutralComp);
+      double S_n = n_neutral * rate;  // [m^-3 s^-1]
+      srcRho[iSpProd] += S_n * mass_prod * cProtonMassSI;
+      // Pressure from neutral temperature
+      if (rxn.neutralComp < nExoComponent) {
+        srcP[iSpProd] += S_n * mass_prod * cProtonMassSI *
+            cBoltzmannSI * exoT0[rxn.neutralComp];
+      }
+    }
+  }
+
+  //-------------------------------------------------------------------
+  // Apply the loss term for a single chemistry reaction to the
+  // per-cell loss array.  rate: SI reaction frequency [s^-1].
+  void chem_apply_loss(const ChemistryReaction& rxn, double rate,
+                       const FluidInterface& other,
+                       const amrex::MFIter& mfi,
+                       const amrex::IntVect& idx, int iLev,
+                       int nIonS, int i, int j, int k,
+                       amrex::Array4<amrex::Real>& lossArr) const {
+    if (rxn.reactantIon <= 0 || rxn.reactantIon > nIonS) return;
+
+    int iSpReac = rxn.reactantIon;
+    int iIonLoss = iSpReac - 1;
+    double rho_reac_norm =
+        other.get_value(mfi, idx, iRho_I[iSpReac], iLev);
+    if (rho_reac_norm <= 0.0) return;
+
+    // Loss rate (normalized) = rate * rho_norm / Si2NoT
+    double lossRho_norm = rate * rho_reac_norm / get_Si2NoT();
+    if (lossRho_norm > 0.0) {
+      lossArr(i, j, k, iIonLoss) += lossRho_norm;
+    }
+  }
+
+  //-------------------------------------------------------------------
+  // Apply #RECOMBINATION loss terms for a single cell.
+  // ne: normalized electron number density; Te_eV: electron temp [eV].
+  void apply_recombination_loss(const FluidInterface& other,
+                                const amrex::MFIter& mfi,
+                                const amrex::IntVect& idx, int iLev,
+                                int nIonS, double ne, double Te_eV,
+                                int i, int j, int k,
+                                amrex::Array4<amrex::Real>& lossArr) const {
+    for (int iR = 0; iR < static_cast<int>(recombIonIndex.size()); ++iR) {
+      int iSp = recombIonIndex[iR];
+      if (iSp < 1 || iSp > nIonS) continue;
+      int iIon = iSp - 1;  // 0-based index in nodeLossFluid
+
+      // k(Te) [cm^3/s] -> [m^3/s]
+      double k_si = recombRate0[iR] * 1e-6;
+      if (Te_eV > 0.0 && recombTempExp[iR] != 0.0) {
+        double Te_K = Te_eV * cUnitChargeSI / cBoltzmannSI;
+        k_si *= pow(recombRefTemp[iR] / Te_K, recombTempExp[iR]);
+      }
+
+      // rho_ion in normalized mass density (from plasma state).
+      double rho_ion_norm =
+          other.get_value(mfi, idx, iRho_I[iSp], iLev);
+      if (rho_ion_norm <= 0.0) continue;
+
+      // Loss rate (normalized):
+      // lossRho_si = k_si * ne_si * rho_ion_si
+      // lossRho_norm = lossRho_si * Si2NoRho / Si2NoT
+      //             = k_si * [ne/(Si2NoRho*mp)] * [rho_norm/Si2NoRho] *
+      //               Si2NoRho / Si2NoT
+      //             = k_si * ne * rho_norm / (Si2NoRho * mp * Si2NoT)
+      double lossRho_norm = k_si * ne * rho_ion_norm /
+          (Si2NoRho * cProtonMassSI * get_Si2NoT());
+      if (lossRho_norm > 0.0) {
+        lossArr(i, j, k, iIon) = lossRho_norm;
+      }
+    }
+  }
+
   //-------------------------------------------------------------------
   // Set nodeFluid from plasma-state-dependent ionization processes.
   void set_source(const FluidInterface& other) override {
@@ -409,12 +577,11 @@ public:
 
           const amrex::Array4<amrex::Real>& arr = nodeFluid[iLev][mfi].array();
 
-          // Loss array (only if loss processes are enabled).
+          // Loss array (allocated when useRecombination or useChemistry
+          // is true, which is guaranteed when doRecomb or doChem is true).
           amrex::Array4<amrex::Real> lossArr;
-          bool hasLossArr = false;
-          if ((doRecomb || doChem) && !nodeLossFluid[iLev].empty()) {
+          if (doRecomb || doChem) {
             lossArr = nodeLossFluid[iLev][mfi].array();
-            hasLossArr = true;
           }
 
           for (int k = lo.z; k <= hi.z; ++k)
@@ -463,18 +630,20 @@ public:
                 std::vector<double> srcRhoUy(nIonS + 1, 0.0);
                 std::vector<double> srcRhoUz(nIonS + 1, 0.0);
 
+                // ---- Accumulate ALL source terms into srcRho/srcP/srcRhoU ----
+                // All source processes (exosphere ionization + chemistry)
+                // must be accumulated BEFORE writing to nodeFluid, so that
+                // the source particle creation sees the complete source.
+
+                // Exosphere-based ionization sources (photoionization,
+                // electron impact, charge exchange).
                 for (int iC = 0; iC < nExoComponent; ++iC) {
-                  // Map exosphere component iC to ion species (iC + 1).
-                  // Species 0 = electron, so ion species index = iC + 1.
                   const int iSp = iC + 1;
-                  if (iSp > nIonS) break;  // safety: not enough ion species
+                  if (iSp > nIonS) break;
 
                   double dens_i =
                       get_exosphere_component_density(r_val, iC);
 
-                  // Sum the per-cell ionization frequency nu [s^-1] from
-                  // each enabled process.  Each *_rate() below operates on
-                  // this single spatial cell.
                   double nu_tot = 0.0;
                   if (doPhoto)
                     nu_tot += photoionization_rate(xyz, iC);
@@ -483,27 +652,38 @@ public:
                     nu_tot += impact_ionization_rate(ne, Te_eV, iC);
                   }
                   if (doCX) {
-                    // Sum the charge-exchange frequency over all ion
-                    // species; each neutral can exchange with every ion.
                     for (int iSpCX = 1; iSpCX <= nIonS; ++iSpCX) {
                       nu_tot += charge_exchange_rate(other, mfi, idx, iLev,
                                                      iSpCX, iC);
                     }
                   }
 
-                  // Number density production rate [m^-3 s^-1]
                   double S_n = dens_i * nu_tot;
-                  // Convert to mass density production rate [kg m^-3 s^-1]
-                  // using the mass of the corresponding ion species.
                   double mass_amu = get_species_mass(iSp);
                   srcRho[iSp] += S_n * mass_amu * cProtonMassSI;
-                  // Pressure source using the neutral temperature
-                  // exoT0[iC] [K] from the #EXOSPHERE profile.
                   srcP[iSp] +=
                       S_n * mass_amu * cProtonMassSI * cBoltzmannSI *
                       exoT0[iC];
                 }
 
+                // General chemistry source terms (#CHEMISTRY).
+                // Must be accumulated here (before nodeFluid write) so the
+                // source particle creation picks them up.
+                if (doChem) {
+                  fetch_electron_plasma();
+                  for (int iR = 0;
+                       iR < static_cast<int>(chemReactions.size()); ++iR) {
+                    const auto& rxn = chemReactions[iR];
+                    double rate = chem_reaction_rate(rxn, xyz, r_val,
+                                                     ne, Te_eV);
+                    if (rate <= 0.0) continue;
+                    chem_apply_source(rxn, rate, other, mfi, idx, iLev,
+                                      nIonS, r_val, srcRho, srcP,
+                                      srcRhoUx, srcRhoUy, srcRhoUz);
+                  }
+                }
+
+                // ---- Write accumulated source terms to nodeFluid ----
                 for (int iFluid = 0; iFluid < nFluid; iFluid++) {
                   arr(i, j, k, iRho_I[iFluid]) = 0;
                   arr(i, j, k, iUx_I[iFluid]) = 0;
@@ -512,20 +692,12 @@ public:
                   arr(i, j, k, iP_I[iFluid]) = 0;
                 }
 
-                // Write per-species source terms.
-                // For photoionization/existing sources: zero momentum
-                // (source particles born at rest).
-                // For cross-species CX: momentum inherited from reactant.
                 bool anySource = false;
                 for (int iSp = 1; iSp <= nIonS; ++iSp) {
                   if (srcRho[iSp] > 0) {
                     anySource = true;
                     double rho_norm = srcRho[iSp] * Si2NoRho / get_Si2NoT();
                     arr(i, j, k, iRho_I[iSp]) = rho_norm;
-                    // Write momentum (rho*u).  If srcRhoU is zero (e.g.
-                    // photoionization), velocity will be zero after
-                    // convert_moment_to_velocity divides by rho.
-                    // If non-zero (cross-species CX), velocity = u_reactant.
                     arr(i, j, k, iUx_I[iSp]) =
                         srcRhoUx[iSp] * Si2NoRho / get_Si2NoT();
                     arr(i, j, k, iUy_I[iSp]) =
@@ -536,7 +708,6 @@ public:
                         srcP[iSp] * Si2NoP / get_Si2NoT();
                   }
                 }
-                // Electron pressure source: sum of all ion sources.
                 if (anySource && iPe >= 0) {
                   double srcPe = 0.0;
                   for (int iSp = 1; iSp <= nIonS; ++iSp)
@@ -544,187 +715,28 @@ public:
                   arr(i, j, k, iPe) = srcPe * Si2NoP / get_Si2NoT();
                 }
 
-                // ---- Recombination loss terms ----
-                // Dissociative recombination: ion+ + e- -> neutrals.
-                // Loss rate L_rho = k(Te) * ne * rho_ion [kg/m^3/s].
-                // Written to nodeLossFluid as normalized mass-density rate.
-                // apply_loss() will reduce particle weights by the
-                // fraction L_rho * dt / rho_existing.
-                if (hasLossArr) {
+                // ---- Compute ALL loss terms (after nodeFluid write) ----
+                // Loss terms write to nodeLossFluid (lossArr), which is
+                // separate from nodeFluid.
+
+                // Recombination loss (#RECOMBINATION).
+                if (doRecomb) {
                   fetch_electron_plasma();
-                  for (int iR = 0; iR < static_cast<int>(recombIonIndex.size());
-                       ++iR) {
-                    int iSp = recombIonIndex[iR];
-                    if (iSp < 1 || iSp > nIonS)
-                      continue;
-                    int iIon = iSp - 1; // 0-based index in nodeLossFluid
-
-                    // k(Te) [cm^3/s] -> [m^3/s]
-                    double k_si = recombRate0[iR] * 1e-6;
-                    if (Te_eV > 0.0 && recombTempExp[iR] != 0.0) {
-                      // Te in Kelvin: Te_K = Te_eV * (e/k_B)
-                      double Te_K = Te_eV * cUnitChargeSI / cBoltzmannSI;
-                      k_si *= pow(recombRefTemp[iR] / Te_K,
-                                  recombTempExp[iR]);
-                    }
-
-                    // rho_ion in normalized mass density (from plasma state).
-                    double rho_ion_norm =
-                        other.get_value(mfi, idx, iRho_I[iSp], iLev);
-                    if (rho_ion_norm <= 0.0)
-                      continue;
-
-                    // Compute the loss rate entirely in SI, then convert
-                    // to normalized units (same as source terms).
-                    double lossRho_norm = k_si * ne * rho_ion_norm /
-                        (Si2NoRho * cProtonMassSI * get_Si2NoT());
-                    if (lossRho_norm > 0.0) {
-                      lossArr(i, j, k, iIon) = lossRho_norm;
-                    }
-                  }
+                  apply_recombination_loss(other, mfi, idx, iLev, nIonS,
+                                            ne, Te_eV, i, j, k, lossArr);
                 }
 
-                // ---- General chemistry (#CHEMISTRY) ----
-                // Handles cross-species charge exchange, photoionization,
-                // and recombination through a unified reaction format.
-                //   reactantIon + neutral -> productIon + neutral'
-                // Source (product ion) -> nodeFluid; Loss (reactant ion)
-                // -> nodeLossFluid.
+                // Chemistry loss terms (#CHEMISTRY).
                 if (doChem) {
+                  fetch_electron_plasma();
                   for (int iR = 0;
                        iR < static_cast<int>(chemReactions.size()); ++iR) {
                     const auto& rxn = chemReactions[iR];
-                    double rate = 0.0; // reaction frequency [s^-1] (SI)
-
-                    if (rxn.rateType == 1) {
-                      // Photoionization: rate = nu0 * (Rp/r)^2 [s^-1]
-                      // Uses rxn.rateCoef as nu0 (not photoNu0 array).
-                      if (is_in_shadow(xyz[0], xyz[1], xyz[2])) {
-                        rate = 0.0;
-                      } else {
-                        double ratio = rPlanetSi / r_val;
-                        rate = rxn.rateCoef * ratio * ratio;
-                      }
-                    } else {
-                      // Thermal rate coefficient k(Te) [cm^3/s] -> [m^3/s]
-                      double k_si = rxn.rateCoef * 1e-6;
-                      if (rxn.tempExp != 0.0) {
-                        fetch_electron_plasma();
-                        if (Te_eV > 0.0) {
-                          double Te_K =
-                              Te_eV * cUnitChargeSI / cBoltzmannSI;
-                          k_si *= pow(rxn.refTemp / Te_K, rxn.tempExp);
-                        }
-                      }
-
-                      if (rxn.neutralComp >= 0) {
-                        // Charge exchange: rate = k * n_neutral [s^-1]
-                        double n_neutral = get_exosphere_component_density(
-                            r_val, rxn.neutralComp);
-                        rate = k_si * n_neutral;
-                      } else {
-                        // Recombination: rate = k * n_e [s^-1]
-                        fetch_electron_plasma();
-                        rate = k_si * ne /
-                               (Si2NoRho * cProtonMassSI);
-                      }
-                    }
-
-                    if (rate <= 0.0)
-                      continue;
-
-                    // ---- Source term for product ion ----
-                    if (rxn.productIon > 0 && rxn.productIon <= nIonS) {
-                      int iSpProd = rxn.productIon;
-                      double mass_prod = get_species_mass(iSpProd);
-
-                      if (rxn.reactantIon > 0 &&
-                          rxn.reactantIon <= nIonS) {
-                        // Cross-species CX: product inherits reactant's
-                        // velocity and temperature.
-                        int iSpReac = rxn.reactantIon;
-                        double rho_reac_norm = other.get_value(
-                            mfi, idx, iRho_I[iSpReac], iLev);
-                        if (rho_reac_norm > 0.0) {
-                          // Number density of reactant (normalized)
-                          double mass_reac =
-                              get_species_mass(iSpReac);
-                          double n_reac_norm = rho_reac_norm / mass_reac;
-
-                          // Source mass density rate (SI):
-                          // srcRho = rate * n_reac * m_prod * mp
-                          double srcRho_si = rate * n_reac_norm *
-                              mass_prod * cProtonMassSI /
-                              Si2NoRho;
-                          srcRho[iSpProd] += srcRho_si;
-
-                          // Source momentum: product inherits reactant
-                          // velocity (normalized).  Momentum rate =
-                          // srcRho * u_reactant.
-                          double ux_reac = other.get_ux(
-                              mfi, idx, iSpReac, iLev);
-                          double uy_reac = other.get_uy(
-                              mfi, idx, iSpReac, iLev);
-                          double uz_reac = other.get_uz(
-                              mfi, idx, iSpReac, iLev);
-                          srcRhoUx[iSpProd] += srcRho_si * ux_reac;
-                          srcRhoUy[iSpProd] += srcRho_si * uy_reac;
-                          srcRhoUz[iSpProd] += srcRho_si * uz_reac;
-
-                          // Source pressure: P = n*k*T, product inherits
-                          // reactant temperature.
-                          double p_reac_norm = other.get_value(
-                              mfi, idx, iP_I[iSpReac], iLev);
-                          // P_source (SI) = rate * n_reac * k * T_reac
-                          // = rate * P_reac (in normalized, then convert)
-                          // P_reac_SI = P_reac_norm / Si2NoP
-                          // srcP = rate * n_reac_norm/Si2NoRho * P_reac_SI
-                          // But n_reac_norm = rho_reac_norm/mass_reac
-                          // and P_reac_SI = P_reac_norm / Si2NoP
-                          // srcP = rate * rho_reac_norm / mass_reac /
-                          //        Si2NoRho * P_reac_norm / Si2NoP
-                          // Simplify: srcP = rate * n_reac_SI * P_reac_SI
-                          double n_reac_si = n_reac_norm /
-                              (Si2NoRho * cProtonMassSI);
-                          double p_reac_si = p_reac_norm / Si2NoP;
-                          srcP[iSpProd] += rate * n_reac_si * p_reac_si;
-                        }
-                      } else {
-                        // Photoionization: source from neutral at rest
-                        double n_neutral = get_exosphere_component_density(
-                            r_val, rxn.neutralComp);
-                        double S_n = n_neutral * rate;
-                        srcRho[iSpProd] +=
-                            S_n * mass_prod * cProtonMassSI;
-                        // Zero velocity (momentum = 0)
-                        // Pressure from neutral temperature
-                        if (rxn.neutralComp < nExoComponent) {
-                          srcP[iSpProd] += S_n * mass_prod *
-                              cProtonMassSI * cBoltzmannSI *
-                              exoT0[rxn.neutralComp];
-                        }
-                      }
-                    }
-
-                    // ---- Loss term for reactant ion ----
-                    if (hasLossArr && rxn.reactantIon > 0 &&
-                        rxn.reactantIon <= nIonS) {
-                      int iSpReac = rxn.reactantIon;
-                      int iIonLoss = iSpReac - 1;
-                      double rho_reac_norm = other.get_value(
-                          mfi, idx, iRho_I[iSpReac], iLev);
-                      if (rho_reac_norm > 0.0) {
-                        // Loss rate (normalized) = rate * rho_norm / Si2NoT
-                        double lossRho_norm =
-                            rate * rho_reac_norm /
-                            (Si2NoRho * get_Si2NoT()) * Si2NoRho;
-                        // Simplify: rate * rho_norm / Si2NoT
-                        lossRho_norm = rate * rho_reac_norm / get_Si2NoT();
-                        if (lossRho_norm > 0.0) {
-                          lossArr(i, j, k, iIonLoss) += lossRho_norm;
-                        }
-                      }
-                    }
+                    double rate = chem_reaction_rate(rxn, xyz, r_val,
+                                                     ne, Te_eV);
+                    if (rate <= 0.0) continue;
+                    chem_apply_loss(rxn, rate, other, mfi, idx, iLev,
+                                    nIonS, i, j, k, lossArr);
                   }
                 }
               } // for k

--- a/userfiles/ExoSource.h
+++ b/userfiles/ExoSource.h
@@ -241,6 +241,21 @@ public:
         param.read_var("tempExponent", recombTempExp[i]);
         param.read_var("refTemp", recombRefTemp[i]);
       }
+    } else if (command == "#CHEMISTRY") {
+      useChemistry = true;
+      useLossSource = true;
+      int nRxns;
+      param.read_var("nReactions", nRxns);
+      chemReactions.resize(nRxns);
+      for (int i = 0; i < nRxns; ++i) {
+        param.read_var("reactantIon", chemReactions[i].reactantIon);
+        param.read_var("productIon", chemReactions[i].productIon);
+        param.read_var("neutralComp", chemReactions[i].neutralComp);
+        param.read_var("rateType", chemReactions[i].rateType);
+        param.read_var("rateCoef", chemReactions[i].rateCoef);
+        param.read_var("tempExp", chemReactions[i].tempExp);
+        param.read_var("refTemp", chemReactions[i].refTemp);
+      }
     }
   }
 
@@ -273,6 +288,44 @@ public:
           amrex::Abort(printPrefix + "Error: #RECOMBINATION rateCoef must "
                        + "be positive (got "
                        + std::to_string(recombRate0[i]) + ").");
+        }
+      }
+    }
+
+    // ---- Chemistry validation ----
+    if (useChemistry) {
+      if (nS < 2) {
+        amrex::Abort(printPrefix + "Error: #CHEMISTRY requires at least "
+                     + "2 plasma species (electron + 1 ion).");
+      }
+      const int nIonS = nS - 1;
+      for (int i = 0; i < static_cast<int>(chemReactions.size()); ++i) {
+        const auto& rxn = chemReactions[i];
+        if (rxn.reactantIon < 0 || rxn.reactantIon > nIonS) {
+          amrex::Abort(printPrefix + "Error: #CHEMISTRY reactantIon "
+                       + std::to_string(rxn.reactantIon) + " out of range "
+                       + "[0, " + std::to_string(nIonS) + "].");
+        }
+        if (rxn.productIon < 0 || rxn.productIon > nIonS) {
+          amrex::Abort(printPrefix + "Error: #CHEMISTRY productIon "
+                       + std::to_string(rxn.productIon) + " out of range "
+                       + "[0, " + std::to_string(nIonS) + "].");
+        }
+        if (rxn.reactantIon == 0 && rxn.productIon == 0) {
+          amrex::Abort(printPrefix + "Error: #CHEMISTRY reaction "
+                       + std::to_string(i) + " has both reactantIon and "
+                       + "productIon = 0 (no-op).");
+        }
+        if (rxn.rateType == 1 && rxn.neutralComp < 0) {
+          amrex::Abort(printPrefix + "Error: #CHEMISTRY photoionization "
+                       + "reaction " + std::to_string(i)
+                       + " requires a neutral component.");
+        }
+        if (rxn.rateType == 0 && rxn.neutralComp < 0 &&
+            rxn.reactantIon == 0) {
+          amrex::Abort(printPrefix + "Error: #CHEMISTRY thermal reaction "
+                       + std::to_string(i) + " with no neutral and no "
+                       + "reactant ion is invalid.");
         }
       }
     }
@@ -341,6 +394,7 @@ public:
     const bool doImpact = useElectronImpact;
     const bool doCX = useChargeExchange;
     const bool doRecomb = useRecombination;
+    const bool doChem = useChemistry;
 
     for (int iLev = 0; iLev < n_lev(); iLev++) {
       if (!nodeFluid[iLev].empty()) {
@@ -358,7 +412,7 @@ public:
           // Loss array (only if loss processes are enabled).
           amrex::Array4<amrex::Real> lossArr;
           bool hasLossArr = false;
-          if (doRecomb && !nodeLossFluid[iLev].empty()) {
+          if ((doRecomb || doChem) && !nodeLossFluid[iLev].empty()) {
             lossArr = nodeLossFluid[iLev][mfi].array();
             hasLossArr = true;
           }
@@ -399,9 +453,15 @@ public:
                 // Species 0 = electron (skipped), 1 = H+, 2 = O+, ...
                 // Exosphere component iC maps to ion species (iC + 1).
                 // srcRho[iS], srcP[iS] in SI [kg m^-3 s^-1, Pa s^-1].
+                // srcRhoU[iS] in SI [kg m^-2 s^-2] (momentum rate).
+                // For cross-species CX, product ion inherits reactant
+                // velocity; srcRhoU stores the accumulated momentum rate.
                 const int nIonS = nS - 1;  // number of ion species
                 std::vector<double> srcRho(nIonS + 1, 0.0);
                 std::vector<double> srcP(nIonS + 1, 0.0);
+                std::vector<double> srcRhoUx(nIonS + 1, 0.0);
+                std::vector<double> srcRhoUy(nIonS + 1, 0.0);
+                std::vector<double> srcRhoUz(nIonS + 1, 0.0);
 
                 for (int iC = 0; iC < nExoComponent; ++iC) {
                   // Map exosphere component iC to ion species (iC + 1).
@@ -452,17 +512,26 @@ public:
                   arr(i, j, k, iP_I[iFluid]) = 0;
                 }
 
-                // Write per-species source terms.  Zero momentum (source
-                // particles are born at rest in the planet frame).
+                // Write per-species source terms.
+                // For photoionization/existing sources: zero momentum
+                // (source particles born at rest).
+                // For cross-species CX: momentum inherited from reactant.
                 bool anySource = false;
                 for (int iSp = 1; iSp <= nIonS; ++iSp) {
                   if (srcRho[iSp] > 0) {
                     anySource = true;
-                    arr(i, j, k, iRho_I[iSp]) =
-                        srcRho[iSp] * Si2NoRho / get_Si2NoT();
-                    arr(i, j, k, iUx_I[iSp]) = 0.0;
-                    arr(i, j, k, iUy_I[iSp]) = 0.0;
-                    arr(i, j, k, iUz_I[iSp]) = 0.0;
+                    double rho_norm = srcRho[iSp] * Si2NoRho / get_Si2NoT();
+                    arr(i, j, k, iRho_I[iSp]) = rho_norm;
+                    // Write momentum (rho*u).  If srcRhoU is zero (e.g.
+                    // photoionization), velocity will be zero after
+                    // convert_moment_to_velocity divides by rho.
+                    // If non-zero (cross-species CX), velocity = u_reactant.
+                    arr(i, j, k, iUx_I[iSp]) =
+                        srcRhoUx[iSp] * Si2NoRho / get_Si2NoT();
+                    arr(i, j, k, iUy_I[iSp]) =
+                        srcRhoUy[iSp] * Si2NoRho / get_Si2NoT();
+                    arr(i, j, k, iUz_I[iSp]) =
+                        srcRhoUz[iSp] * Si2NoRho / get_Si2NoT();
                     arr(i, j, k, iP_I[iSp]) =
                         srcP[iSp] * Si2NoP / get_Si2NoT();
                   }
@@ -511,6 +580,150 @@ public:
                         (Si2NoRho * cProtonMassSI * get_Si2NoT());
                     if (lossRho_norm > 0.0) {
                       lossArr(i, j, k, iIon) = lossRho_norm;
+                    }
+                  }
+                }
+
+                // ---- General chemistry (#CHEMISTRY) ----
+                // Handles cross-species charge exchange, photoionization,
+                // and recombination through a unified reaction format.
+                //   reactantIon + neutral -> productIon + neutral'
+                // Source (product ion) -> nodeFluid; Loss (reactant ion)
+                // -> nodeLossFluid.
+                if (doChem) {
+                  for (int iR = 0;
+                       iR < static_cast<int>(chemReactions.size()); ++iR) {
+                    const auto& rxn = chemReactions[iR];
+                    double rate = 0.0; // reaction frequency [s^-1] (SI)
+
+                    if (rxn.rateType == 1) {
+                      // Photoionization: rate = nu0 * (Rp/r)^2 [s^-1]
+                      // Uses rxn.rateCoef as nu0 (not photoNu0 array).
+                      if (is_in_shadow(xyz[0], xyz[1], xyz[2])) {
+                        rate = 0.0;
+                      } else {
+                        double ratio = rPlanetSi / r_val;
+                        rate = rxn.rateCoef * ratio * ratio;
+                      }
+                    } else {
+                      // Thermal rate coefficient k(Te) [cm^3/s] -> [m^3/s]
+                      double k_si = rxn.rateCoef * 1e-6;
+                      if (rxn.tempExp != 0.0) {
+                        fetch_electron_plasma();
+                        if (Te_eV > 0.0) {
+                          double Te_K =
+                              Te_eV * cUnitChargeSI / cBoltzmannSI;
+                          k_si *= pow(rxn.refTemp / Te_K, rxn.tempExp);
+                        }
+                      }
+
+                      if (rxn.neutralComp >= 0) {
+                        // Charge exchange: rate = k * n_neutral [s^-1]
+                        double n_neutral = get_exosphere_component_density(
+                            r_val, rxn.neutralComp);
+                        rate = k_si * n_neutral;
+                      } else {
+                        // Recombination: rate = k * n_e [s^-1]
+                        fetch_electron_plasma();
+                        rate = k_si * ne /
+                               (Si2NoRho * cProtonMassSI);
+                      }
+                    }
+
+                    if (rate <= 0.0)
+                      continue;
+
+                    // ---- Source term for product ion ----
+                    if (rxn.productIon > 0 && rxn.productIon <= nIonS) {
+                      int iSpProd = rxn.productIon;
+                      double mass_prod = get_species_mass(iSpProd);
+
+                      if (rxn.reactantIon > 0 &&
+                          rxn.reactantIon <= nIonS) {
+                        // Cross-species CX: product inherits reactant's
+                        // velocity and temperature.
+                        int iSpReac = rxn.reactantIon;
+                        double rho_reac_norm = other.get_value(
+                            mfi, idx, iRho_I[iSpReac], iLev);
+                        if (rho_reac_norm > 0.0) {
+                          // Number density of reactant (normalized)
+                          double mass_reac =
+                              get_species_mass(iSpReac);
+                          double n_reac_norm = rho_reac_norm / mass_reac;
+
+                          // Source mass density rate (SI):
+                          // srcRho = rate * n_reac * m_prod * mp
+                          double srcRho_si = rate * n_reac_norm *
+                              mass_prod * cProtonMassSI /
+                              Si2NoRho;
+                          srcRho[iSpProd] += srcRho_si;
+
+                          // Source momentum: product inherits reactant
+                          // velocity (normalized).  Momentum rate =
+                          // srcRho * u_reactant.
+                          double ux_reac = other.get_ux(
+                              mfi, idx, iSpReac, iLev);
+                          double uy_reac = other.get_uy(
+                              mfi, idx, iSpReac, iLev);
+                          double uz_reac = other.get_uz(
+                              mfi, idx, iSpReac, iLev);
+                          srcRhoUx[iSpProd] += srcRho_si * ux_reac;
+                          srcRhoUy[iSpProd] += srcRho_si * uy_reac;
+                          srcRhoUz[iSpProd] += srcRho_si * uz_reac;
+
+                          // Source pressure: P = n*k*T, product inherits
+                          // reactant temperature.
+                          double p_reac_norm = other.get_value(
+                              mfi, idx, iP_I[iSpReac], iLev);
+                          // P_source (SI) = rate * n_reac * k * T_reac
+                          // = rate * P_reac (in normalized, then convert)
+                          // P_reac_SI = P_reac_norm / Si2NoP
+                          // srcP = rate * n_reac_norm/Si2NoRho * P_reac_SI
+                          // But n_reac_norm = rho_reac_norm/mass_reac
+                          // and P_reac_SI = P_reac_norm / Si2NoP
+                          // srcP = rate * rho_reac_norm / mass_reac /
+                          //        Si2NoRho * P_reac_norm / Si2NoP
+                          // Simplify: srcP = rate * n_reac_SI * P_reac_SI
+                          double n_reac_si = n_reac_norm /
+                              (Si2NoRho * cProtonMassSI);
+                          double p_reac_si = p_reac_norm / Si2NoP;
+                          srcP[iSpProd] += rate * n_reac_si * p_reac_si;
+                        }
+                      } else {
+                        // Photoionization: source from neutral at rest
+                        double n_neutral = get_exosphere_component_density(
+                            r_val, rxn.neutralComp);
+                        double S_n = n_neutral * rate;
+                        srcRho[iSpProd] +=
+                            S_n * mass_prod * cProtonMassSI;
+                        // Zero velocity (momentum = 0)
+                        // Pressure from neutral temperature
+                        if (rxn.neutralComp < nExoComponent) {
+                          srcP[iSpProd] += S_n * mass_prod *
+                              cProtonMassSI * cBoltzmannSI *
+                              exoT0[rxn.neutralComp];
+                        }
+                      }
+                    }
+
+                    // ---- Loss term for reactant ion ----
+                    if (hasLossArr && rxn.reactantIon > 0 &&
+                        rxn.reactantIon <= nIonS) {
+                      int iSpReac = rxn.reactantIon;
+                      int iIonLoss = iSpReac - 1;
+                      double rho_reac_norm = other.get_value(
+                          mfi, idx, iRho_I[iSpReac], iLev);
+                      if (rho_reac_norm > 0.0) {
+                        // Loss rate (normalized) = rate * rho_norm / Si2NoT
+                        double lossRho_norm =
+                            rate * rho_reac_norm /
+                            (Si2NoRho * get_Si2NoT()) * Si2NoRho;
+                        // Simplify: rate * rho_norm / Si2NoT
+                        lossRho_norm = rate * rho_reac_norm / get_Si2NoT();
+                        if (lossRho_norm > 0.0) {
+                          lossArr(i, j, k, iIonLoss) += lossRho_norm;
+                        }
+                      }
                     }
                   }
                 }

--- a/userfiles/ExoSource.h
+++ b/userfiles/ExoSource.h
@@ -226,12 +226,57 @@ public:
         solarDir[1] /= norm;
         solarDir[2] /= norm;
       }
+    } else if (command == "#RECOMBINATION") {
+      useRecombination = true;
+      useLossSource = true;
+      int nRecomb;
+      param.read_var("nReactions", nRecomb);
+      recombIonIndex.resize(nRecomb);
+      recombRate0.resize(nRecomb);
+      recombTempExp.resize(nRecomb);
+      recombRefTemp.resize(nRecomb);
+      for (int i = 0; i < nRecomb; ++i) {
+        param.read_var("ionSpecies", recombIonIndex[i]);
+        param.read_var("rateCoef", recombRate0[i]);
+        param.read_var("tempExponent", recombTempExp[i]);
+        param.read_var("refTemp", recombRefTemp[i]);
+      }
     }
   }
 
   //-------------------------------------------------------------------
   // Validate consistency between exosphere and ionization commands.
   void post_process_param() override {
+    // ---- Recombination validation (always executed, even without
+    // exosphere, since recombination does not depend on neutrals). ----
+    if (useRecombination) {
+      if (nS < 1) {
+        amrex::Abort(printPrefix + "Error: #RECOMBINATION requires "
+                     + "plasma species. Use #PLASMA to set species.");
+      }
+      // Recombination requires electron density and temperature, which
+      // are only available in useElectronFluid mode (species 0 = electron).
+      if (!useElectronFluid) {
+        amrex::Abort(printPrefix + "Error: #RECOMBINATION requires "
+                     + "useElectronFluid = true (species 0 must be the "
+                     + "electron). Set #PLASMA with an electron species.");
+      }
+      const int nIonS = nS - 1;
+      for (int i = 0; i < static_cast<int>(recombIonIndex.size()); ++i) {
+        int iSp = recombIonIndex[i];
+        if (iSp < 1 || iSp > nIonS) {
+          amrex::Abort(printPrefix + "Error: #RECOMBINATION ionSpecies "
+                       + std::to_string(iSp) + " is out of range [1, "
+                       + std::to_string(nIonS) + "].");
+        }
+        if (recombRate0[i] <= 0.0) {
+          amrex::Abort(printPrefix + "Error: #RECOMBINATION rateCoef must "
+                       + "be positive (got "
+                       + std::to_string(recombRate0[i]) + ").");
+        }
+      }
+    }
+
     if (exosphereType == "None") return;
 
     // The source code assumes species 0 is the electron (used for ne and Te
@@ -287,6 +332,7 @@ public:
     amrex::Print() << nameFunc << " is called.";
 
     set_node_fluid(other);
+    set_node_loss_fluid_to_zero();
 
     // Global NODE box.
     const amrex::Box gbx = convert(Geom(0).Domain(), { AMREX_D_DECL(1, 1, 1) });
@@ -294,6 +340,7 @@ public:
     const bool doPhoto = usePhotoIonization;
     const bool doImpact = useElectronImpact;
     const bool doCX = useChargeExchange;
+    const bool doRecomb = useRecombination;
 
     for (int iLev = 0; iLev < n_lev(); iLev++) {
       if (!nodeFluid[iLev].empty()) {
@@ -307,6 +354,14 @@ public:
           const auto hi = ubound(box);
 
           const amrex::Array4<amrex::Real>& arr = nodeFluid[iLev][mfi].array();
+
+          // Loss array (only if loss processes are enabled).
+          amrex::Array4<amrex::Real> lossArr;
+          bool hasLossArr = false;
+          if (doRecomb && !nodeLossFluid[iLev].empty()) {
+            lossArr = nodeLossFluid[iLev][mfi].array();
+            hasLossArr = true;
+          }
 
           for (int k = lo.z; k <= hi.z; ++k)
             for (int j = lo.y; j <= hi.y; ++j)
@@ -418,6 +473,46 @@ public:
                   for (int iSp = 1; iSp <= nIonS; ++iSp)
                     srcPe += srcP[iSp];
                   arr(i, j, k, iPe) = srcPe * Si2NoP / get_Si2NoT();
+                }
+
+                // ---- Recombination loss terms ----
+                // Dissociative recombination: ion+ + e- -> neutrals.
+                // Loss rate L_rho = k(Te) * ne * rho_ion [kg/m^3/s].
+                // Written to nodeLossFluid as normalized mass-density rate.
+                // apply_loss() will reduce particle weights by the
+                // fraction L_rho * dt / rho_existing.
+                if (hasLossArr) {
+                  fetch_electron_plasma();
+                  for (int iR = 0; iR < static_cast<int>(recombIonIndex.size());
+                       ++iR) {
+                    int iSp = recombIonIndex[iR];
+                    if (iSp < 1 || iSp > nIonS)
+                      continue;
+                    int iIon = iSp - 1; // 0-based index in nodeLossFluid
+
+                    // k(Te) [cm^3/s] -> [m^3/s]
+                    double k_si = recombRate0[iR] * 1e-6;
+                    if (Te_eV > 0.0 && recombTempExp[iR] != 0.0) {
+                      // Te in Kelvin: Te_K = Te_eV * (e/k_B)
+                      double Te_K = Te_eV * cUnitChargeSI / cBoltzmannSI;
+                      k_si *= pow(recombRefTemp[iR] / Te_K,
+                                  recombTempExp[iR]);
+                    }
+
+                    // rho_ion in normalized mass density (from plasma state).
+                    double rho_ion_norm =
+                        other.get_value(mfi, idx, iRho_I[iSp], iLev);
+                    if (rho_ion_norm <= 0.0)
+                      continue;
+
+                    // Compute the loss rate entirely in SI, then convert
+                    // to normalized units (same as source terms).
+                    double lossRho_norm = k_si * ne * rho_ion_norm /
+                        (Si2NoRho * cProtonMassSI * get_Si2NoT());
+                    if (lossRho_norm > 0.0) {
+                      lossArr(i, j, k, iIon) = lossRho_norm;
+                    }
+                  }
                 }
               } // for k
         }


### PR DESCRIPTION
- Add loss term support via weight adjustment and macro-particle removal. This is required for a more complete implementation of the sources and sinks.
- Add `#CHEMISTRY` for supporting generic chemical reactions that supersedes the simpler `#PHOTOIONIZATION`, `#CHARGEEXCHANGE`, and `#RECOMBINATION` commands. If this turns out to be more useful in practice, we can later clean up the code to maintain `#CHEMISTRY` only.
- Extra care is paid to the maintenance of charge neutrality. The user is responsible for satisfying the initial charge neutrality (`#INITIALSTATE` in the standalone mode). Later, charge neutrality is guaranteed by FLEKS.
- Two new standalone tests are added: `recombination` and `chemistry`.

-----

The standalone test fails because I forget to configure `-u=Exo` for the exosphere source terms in CI. This has also been fixed, but will not show up in this PR. The `PostIDL.exe` miss is also fixed by locating the compiled executable in the Python script.