### PR TITLE
Add light-wave AMR test to standalone suite

### DIFF
--- a/.github/workflows/standalone_test.yml
+++ b/.github/workflows/standalone_test.yml
@@ -79,15 +79,21 @@ jobs:
           path: |
             SWMF/PC/FLEKS/bin/FLEKS.exe
             SWMF/bin/PostIDL.exe
-          key: ${{ runner.os }}-fleks-standalone-v2-${{ hashFiles('SWMF/PC/FLEKS/**/*.cpp', 'SWMF/PC/FLEKS/**/*.h', 'SWMF/PC/FLEKS/**/Makefile*') }}
+          # Bumped v2 -> v3 because the build now requires nLevMax=2 (-lev=2),
+          # and the source-hash-only key would otherwise restore a stale
+          # nLevMax=1 binary and skip the rebuild (cache-hit).
+          key: ${{ runner.os }}-fleks-standalone-v3-${{ hashFiles('SWMF/PC/FLEKS/**/*.cpp', 'SWMF/PC/FLEKS/**/*.h', 'SWMF/PC/FLEKS/**/Makefile*') }}
           restore-keys: |
-            ${{ runner.os }}-fleks-standalone-v2-
+            ${{ runner.os }}-fleks-standalone-v3-
 
       - name: Build Standalone FLEKS
         if: steps.cache-standalone.outputs.cache-hit != 'true'
         working-directory: SWMF/PC/FLEKS
         run: |
-          ./Config.pl -u=Exo
+          # Build with two grid levels (nLevMax>=2): the lightwave test uses
+          # #REFINEREGION, which requires max_level > 0 and aborts at startup
+          # (MPI_ABORT errorcode 6) when built with the default nLevMax=1.
+          ./Config.pl -u=Exo -lev=2
           make EXE -j$(nproc)
           make PIDL
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,6 +18,8 @@ Each test case is contained within its own dedicated subdirectory containing a
 |                   |                    | (T ~ 100,000 K), only electron impact enabled            |
 | Charge exchange   | `chargeexchange/`  | Constant CX cross-section with flowing solar wind ions,  |
 |                   |                    | only charge exchange enabled                             |
+| Light wave        | `lightwave/`       | 3D vacuum transverse EM (light) wave on a periodic AMR  |
+|                   |                    | grid; energy-conservation check (needs `nLevMax >= 2`)   |
 | Performance       | `performance/`     | Beam-based scaling benchmark (excluded from CI suite)    |
 
 ### Ionization Parameter Commands
@@ -34,6 +36,27 @@ All three can be combined (as in `tests/photoionization/`) or tested individuall
 ## Architecture
 
 Ionization parameters are stored in `SourceInterface` (not `FluidInterface`) and read by `UserSource::read_param()` in `userfiles/ExoSource.h`. The Domain routes `#PHOTOIONIZATION`, `#ELECTRONIMPACT`, and `#CHARGEEXCHANGE` commands to the source object rather than to `FluidInterface`. This keeps the MHD coupling layer uncluttered by ionization-specific data.
+
+## Building the Test Executable
+
+All standalone tests, including the `lightwave` AMR test, run with a **single
+FLEKS executable built with two grid levels** (`nLevMax >= 2`):
+
+```bash
+cd PC/FLEKS            # (or the FLEKS root)
+./Config.pl -lev=2
+make -j4
+```
+
+The AMR machinery is always compiled in; with `nLevMax = 2` the binary can run
+both refinement-based tests (e.g. `lightwave`) and the non-refinement tests
+(`beam`, ionization cases, etc.). For the latter no `#REFINEREGION` is defined,
+so the run stays at the base level (`n_lev() == 1`) and behaves identically to
+a `nLevMax = 1` build. A plain `nLevMax = 1` build will **abort at start-up** on
+`lightwave` because its `#REFINEREGION` command requires `max_level > 0`.
+
+> Note: the test runner uses `bin/FLEKS.exe` for every test, so one `-lev=2`
+> build serves the entire suite. There is no need for a separate AMR binary.
 
 ## Running the Tests
 
@@ -70,7 +93,8 @@ with an error listing the available tests. When the flag is omitted, all tests
 are run (the default behavior). The flag may be combined with `-n`/`--nprocs`.
 
 The script:
-1. Scans subdirectories of `tests/` for a `PARAM.in` file, excluding `performance/`.
+1. Scans subdirectories of `tests/` for a `PARAM.in` file, excluding `performance/`
+   and the shared `run_test/` execution directory.
 2. Creates the execution directory `run_test/` with necessary symlinks to the
    FLEKS executable and post-processing tools.
 3. Copies `PARAM.in` from the test folder, executes `./FLEKS.exe` (or via
@@ -104,4 +128,5 @@ expected results, and instructions for manual execution:
 | `photoionization/` | [README](photoionization/README.md)  |
 | `electronimpact/`  | [README](electronimpact/README.md)   |
 | `chargeexchange/`  | [README](chargeexchange/README.md)   |
+| `lightwave/`       | [README](lightwave/README.md)        |
 | `performance/`     | — (see `validate_performance.py`)    |

--- a/tests/lightwave/PARAM.in
+++ b/tests/lightwave/PARAM.in
@@ -61,7 +61,9 @@ T                       useFixedDt
 
 #DISCRETIZATION
 0.50                    theta
-0.0                     coefDiff
+0.0                     ratioDivC2C
+
+legacy keyword, mirrors SWMF test25 byte-for-byte. FieldSolver reads #DISCRETIZATION POSITIONALLY (theta, then coefDiff), so the name is cosmetic; 0.0 disables the divergence-blending diffusion (coefDiff) for the energy-conserving wave.
 
 #MONITOR
 10                      dnReport

--- a/tests/lightwave/PARAM.in
+++ b/tests/lightwave/PARAM.in
@@ -1,0 +1,104 @@
+#DESCRIPTION
+3D Light Wave in Periodic PIC with AMR (standalone FLEKS)
+
+#INITFROMSWMF
+F                       initFromSWMF
+
+#GEOMETRY
+-40.0                   xMin
+ 40.0                   xMax
+-30.0                   yMin
+ 30.0                   yMax
+-4.0                    zMin
+ 4.0                    zMax
+
+#NCELL
+80                      nCellX
+60                      nCellY
+8                       nCellZ
+
+#MAXBLOCKSIZE
+20                      maxBlockSizeX
+20                      maxBlockSizeY
+2                       maxBlockSizeZ
+
+#PERIODICITY
+T                       isPeriodicX
+T                       isPeriodicY
+T                       isPeriodicZ
+
+#SOLVEEM
+T                       solveEM
+
+#PLASMA
+1                       nSpecies
+0.01                    mass        Species 0: electron (background)
+-1.0                    charge
+
+#UNIFORMSTATE
+1.0                     rho [amu/cc]   Species 0: electron background
+0.0                     ux [km/s]
+0.0                     uy [km/s]
+0.0                     uz [km/s]
+1.0e4                   T [K]
+0.0                     bx [T]
+0.0                     by [T]
+0.0                     bz [T]
+0.0                     ex [V/m]
+0.0                     ey [V/m]
+0.0                     ez [V/m]
+
+#NORMALIZATION
+1.0                     lNormSI
+1.0                     uNormSI
+
+#TESTCASE
+lightwave               testCase
+
+#TIMESTEPPING
+T                       useFixedDt
+0.4                     dt
+
+#DISCRETIZATION
+0.50                    theta
+0.0                     coefDiff
+
+#MONITOR
+10                      dnReport
+
+#DIVE
+F                       doCorrectDivE
+
+#REGION
+region1                name
+box                     shape
+-20.0                   min
+ 20.0                   max
+-15.0                   min
+ 15.0                   max
+-2.0                    min
+ 2.0                    max
+
+#REFINEREGION
+0                       iLev
++region1                regions
+
+#GRIDEFFICIENCY
+1.0                     gridEfficiency
+
+#RESAMPLING
+F                       doReSampling
+
+#SAVEPLOT
+1                       nPlot
+z=0 var ascii planet    plotString
+-1                      dnSavePlot
+10.0                    dtSavePlot
+-1                      dxSavePlot
+Ex Ey Ez Bx By Bz       plotVar
+
+#STOP
+-1                      MaxIter
+10.0                    TimeMax
+
+#RUN

--- a/tests/lightwave/PARAM.in
+++ b/tests/lightwave/PARAM.in
@@ -63,7 +63,11 @@ T                       useFixedDt
 0.50                    theta
 0.0                     ratioDivC2C
 
-legacy keyword, mirrors SWMF test25 byte-for-byte. FieldSolver reads #DISCRETIZATION POSITIONALLY (theta, then coefDiff), so the name is cosmetic; 0.0 disables the divergence-blending diffusion (coefDiff) for the energy-conserving wave.
+CAVEAT: line mirrors SWMF test25 (PARAM.in.test.FLEKS.AMR.LightWave.3D) for
+        byte-for-byte parity. The FieldSolver reads DISCRETIZATION values
+        POSITIONALLY (theta, then coefDiff); the keyword name is cosmetic.
+        0.0 disables the divergence-blending diffusion (coefDiff), giving the
+        intended energy-conserving transverse wave.
 
 #MONITOR
 10                      dnReport

--- a/tests/lightwave/README.md
+++ b/tests/lightwave/README.md
@@ -1,0 +1,69 @@
+# 3D Light Wave in Periodic PIC with Adaptive Mesh Refinement
+
+## Description
+
+This test is a standalone migration of the coupled SWMF test
+`Param/PARAM.in.test.FLEKS.AMR.LightWave.3D` (SWMF `Makefile.test` **test25**).
+
+In the coupled run the GM/MHD component only supplied a uniform background
+state and the PIC region; the PC component then initialised a transverse
+electromagnetic (light) wave via `testCase = lightwave`.  This standalone
+version reproduces the same physics directly: a vacuum transverse EM wave
+(`nPartPerCell = 0`, so no macroparticles are loaded) propagating on a
+**periodic AMR grid**.
+
+## Physics & Solver Setup
+
+- **Geometry & Boundaries**: 3D periodic box
+  $x \in [-40, 40]$, $y \in [-30, 30]$, $z \in [-4, 4]$ (all in metres, with
+  the normalized PIC units $l_{\rm norm}=1\,{\rm m}$, $u_{\rm norm}=1\,{\rm m/s}$,
+  i.e. $c=1$).  Resolution $\Delta x = \Delta y = \Delta z = 1.0$.
+- **Initial condition**: `fill_lightwaves(48.0)` fills the node E and B fields
+  with an analytic transverse plane wave of wavelength $\lambda = 48$
+  (normalized length units), propagating diagonally in the $x$–$y$ plane
+  (wave-vector $\propto 0.6\hat{x} + 0.8\hat{y}$).  Both E and B have
+  amplitudes up to $0.8$.
+- **Time stepping**: fixed $\Delta t = 0.4$ (CFL $\approx 0.4$).
+- **Discretization**: $\theta = 0.5$ (Crank–Nicolson-like), no explicit
+  diffusion (${\rm coefDiff}=0$), divergence correction of E disabled
+  (`doCorrectDivE = F`).
+- **AMR**: a refinement region `region1` ($x\in[-20,20]$, $y\in[-15,15]$,
+  $z\in[-2,2]$) is tagged for refinement at level 1 with
+  `gridEfficiency = 1.0`.  Base blocks are $20\times20\times2$ so that several
+  base blocks lie entirely inside `region1` and are refined.
+
+## Requirements
+
+AMR requires FLEKS to be built with `nLevMax >= 2` (the default is `nLevMax = 1`,
+which disables refinement).  Enable it and rebuild before running:
+
+```bash
+cd PC/FLEKS && ./Config.pl -lev=2 && make -j4
+```
+
+With `nLevMax = 1` the `#REFINEREGION` command aborts at startup
+(`iLev` must be smaller than the max level index), so the test cannot run
+without AMR support.
+
+## Expected Results
+
+- The transverse EM wave propagates across the periodic domain and is
+  refined inside `region1`.
+- The total electromagnetic energy $E_{\rm tot} = E_e + E_b$ (written to
+  `log_pic_n*.log`) is non-zero at $t=0$ and remains approximately conserved
+  over the run (a vacuum Maxwell wave should not decay to zero or blow up).
+- The plot output (`z=0` slice of `Ex Ey Ez Bx By Bz`) shows a non-zero field
+  amplitude, i.e. the wave is present at the final time.
+
+## Running
+
+From the FLEKS root directory (requires `bin/FLEKS.exe` built with AMR):
+
+```bash
+python3 tests/validate_tests.py --test=lightwave
+```
+
+The validation checks (1) energy conservation from the `log_pic` energy log
+($0.3 \le E_{\rm tot}^{\rm final}/E_{\rm tot}^{\rm initial} \le 3.0$, both
+non-zero and finite) and (2) that the final plot frame contains a non-zero
+magnetic-field amplitude (the wave is present).

--- a/tests/validate_tests.py
+++ b/tests/validate_tests.py
@@ -389,6 +389,65 @@ def validate_recombination(pic_diags=None, test_name=None):
         return False, "; ".join(reasons)
 
 
+def validate_lightwave(pic_diags=None, test_name=None):
+    """Validate the 3D light-wave (vacuum transverse EM wave) test.
+
+    The light-wave initial condition (testCase = lightwave) fills the node E
+    and B fields with an analytic transverse plane wave; with
+    nPartPerCell = 0 the PIC loads no macroparticles, so the total energy is
+    purely electromagnetic (Ee + Eb).  On a periodic vacuum grid the wave
+    should propagate without the energy decaying to zero or blowing up, so
+    the total EM energy is approximately conserved.
+
+    Checks (from log_pic_n*.log):
+      1. Etot at the first and last frame is finite and > 0 (wave present).
+      2. Energy is approximately conserved:
+         0.3 <= Etot_final / Etot_initial <= 3.0.
+    """
+    import math
+    print("Validating Light Wave Test...")
+
+    if not pic_diags or len(pic_diags) < 2:
+        print("  [INFO] No PIC energy log found; skipping energy checks.")
+        return True, "Passed (no pic log)"
+
+    first = pic_diags[0]
+    last = pic_diags[-1]
+
+    e0 = first.get("Etot", 0.0)
+    e1 = last.get("Etot", 0.0)
+
+    print(f"  --- Energy Diagnostics (from log_pic log) ---")
+    print(f"    Etot (t={first.get('time', 0):.4f}): {e0:.6e}")
+    print(f"    Etot (t={last.get('time', 0):.4f}): {e1:.6e}")
+
+    if not (math.isfinite(e0) and math.isfinite(e1)):
+        print("    FAIL: Non-finite total EM energy.")
+        return False, "Non-finite total EM energy"
+
+    if e0 <= 0:
+        print("    FAIL: Initial total EM energy is zero -- "
+              "wave not initialised.")
+        return False, "Initial Etot is zero (wave not initialised)"
+
+    if e1 <= 0:
+        print("    FAIL: Final total EM energy is zero -- wave collapsed.")
+        return False, "Final Etot is zero (wave collapsed)"
+
+    ratio = e1 / e0
+    lower, upper = 0.3, 3.0
+    print(f"    Etot_final / Etot_initial = {ratio:.4f} "
+          f"(allowed [{lower}, {upper}])")
+
+    if ratio < lower or ratio > upper:
+        print("    FAIL: total EM energy changed outside the allowed range -- "
+              "possible blow-up or unphysical decay.")
+        return False, f"Etot ratio {ratio:.3f} outside [{lower}, {upper}]"
+
+    print(f"    SUCCESS: light wave energy conserved (ratio = {ratio:.3f}).")
+    return True, "Passed"
+
+
 def validate_ionization_source(pic_diags=None, test_name=None):
     """Validate an ionization source test (photoionization, electron impact,
     or charge exchange).
@@ -1025,6 +1084,62 @@ def _check_charge_exchange_source_profile():
     return True, "Passed"
 
 
+def _check_lightwave_present():
+    """Verify the light wave is present in the final plot output.
+
+    Reads the final .out file (produced by PostProc.pl) and checks that the
+    magnetic-field amplitude (BX/BY/BZ) is non-zero somewhere on the slice,
+    confirming the transverse EM wave was initialised and is still present at
+    the final time.
+
+    Returns (passed: bool, reason: str).
+    """
+    import glob
+
+    plots_dir = os.path.join("run_test", "PC", "plots")
+    out_files = sorted(glob.glob(os.path.join(plots_dir, "*.out")))
+    if not out_files:
+        print("    [LW] No .out files found (PostProc.pl not run?).")
+        return True, "No .out files (skipped)"
+
+    out_file = out_files[-1]
+    print(f"    [LW] Loading .out: {os.path.basename(out_file)}")
+
+    with open(out_file, "r") as f:
+        lines = f.readlines()
+    if len(lines) < 6:
+        return True, "Short .out file"
+
+    var_names = lines[4].split()
+    vidx = {v.upper(): i for i, v in enumerate(var_names)}
+    b_idx = []
+    for target in ("BX", "BY", "BZ"):
+        if target in vidx:
+            b_idx.append(vidx[target])
+    if not b_idx:
+        return True, "BX/BY/BZ not in .out"
+
+    bmax = 0.0
+    for line in lines[5:]:
+        cols = line.split()
+        if max(b_idx) >= len(cols):
+            continue
+        try:
+            for i in b_idx:
+                v = abs(float(cols[i]))
+                if v > bmax:
+                    bmax = v
+        except (ValueError, IndexError):
+            continue
+
+    print(f"    [LW] Max |B| amplitude on slice: {bmax:.4e}")
+    if bmax <= 0.0:
+        print("    [LW] FAIL: magnetic field is zero -- wave not present.")
+        return False, "Magnetic field is zero (wave not present)"
+    print("    [LW] Light wave present: VERIFIED")
+    return True, "Passed"
+
+
 def validate_plot_output(test_name):
     """Validate simulation plot output files for a given test.
 
@@ -1055,6 +1170,12 @@ def validate_plot_output(test_name):
     if test_name == "chargeexchange":
         print("  --- Validating Output Files (CX source profile) ---")
         result, reason = _check_charge_exchange_source_profile()
+        return result, reason
+
+    # ---- Light wave: transverse EM wave must be present in the output ----
+    if test_name == "lightwave":
+        print("  --- Validating Output Files (light wave present) ---")
+        result, reason = _check_lightwave_present()
         return result, reason
 
     # ---- Other tests: no plot-file validation ----
@@ -1114,14 +1235,19 @@ def main():
         "chargeexchange": validate_ionization_source,
         "recombination": validate_recombination,
         "chemistry": validate_chemistry,
+        "lightwave": validate_lightwave,
     }
     
     # Discover test subdirectories under tests/
     tests_dir = "tests"
     
     # Iterate through sorted subdirectories
+    # Exclude "performance" (benchmark, not a pass/fail test) and "run_test"
+    # (the shared run directory created by prepare_run_dir, which contains a
+    # PARAM.in and would otherwise be discovered and re-run as a test).
     subdirs = sorted([d for d in os.listdir(tests_dir) 
-                      if os.path.isdir(os.path.join(tests_dir, d)) and d not in ["performance"]])
+                      if os.path.isdir(os.path.join(tests_dir, d))
+                      and d not in ["performance", "run_test"]])
     
     tests = []
     for d in subdirs:


### PR DESCRIPTION
Migrate the light wave test under an AMR mesh from test25 in SWMF to standalone FLEKS.