### PR TITLE
Param loading refactor

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,20 +13,12 @@ jobs:
     permissions:
       contents: write
     steps:
-    - name: Checkout base repository
+    - name: Checkout
       uses: actions/checkout@v6
       with:
-        repository: ${{ github.repository }}
+        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+        ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
         token: ${{ secrets.GITHUB_TOKEN }}
-
-    # For pull_request_target, the PR head ref is exposed on the base repo as
-    # refs/pull/<number>/head. Fetch it so we format the PR's code (not master)
-    # without checking out untrusted fork code directly.
-    - name: Fetch and checkout PR head
-      if: github.event_name == 'pull_request_target'
-      run: |
-        git fetch origin "refs/pull/${{ github.event.pull_request.number }}/head:pr-head"
-        git checkout pr-head
 
     - name: Set up tools
       run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,12 +13,20 @@ jobs:
     permissions:
       contents: write
     steps:
-    - name: Checkout
+    - name: Checkout base repository
       uses: actions/checkout@v6
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-        ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+        repository: ${{ github.repository }}
         token: ${{ secrets.GITHUB_TOKEN }}
+
+    # For pull_request_target, the PR head ref is exposed on the base repo as
+    # refs/pull/<number>/head. Fetch it so we format the PR's code (not master)
+    # without checking out untrusted fork code directly.
+    - name: Fetch and checkout PR head
+      if: github.event_name == 'pull_request_target'
+      run: |
+        git fetch origin "refs/pull/${{ github.event.pull_request.number }}/head:pr-head"
+        git checkout pr-head
 
     - name: Set up tools
       run: |

--- a/include/Domain.h
+++ b/include/Domain.h
@@ -29,6 +29,11 @@ private:
 
   bool useSource = false;
 
+  // Parameter container for the test-particle (ParticleTracker) component.
+  // Populated by Domain::read_param (#TP* commands) and resolved in
+  // ParticleTrackerInfo::post_process_param(); consumed by ParticleTracker.
+  ParticleTrackerInfo ptInfo;
+
   bool isTCInitialized = false;
 
 public:

--- a/include/Domain.h
+++ b/include/Domain.h
@@ -29,9 +29,6 @@ private:
 
   bool useSource = false;
 
-  // Parameter container for the test-particle (ParticleTracker) component.
-  // Populated by Domain::read_param (#TP* commands) and resolved in
-  // ParticleTrackerInfo::post_process_param(); consumed by ParticleTracker.
   ParticleTrackerInfo ptInfo;
 
   bool isTCInitialized = false;

--- a/include/Domain.h
+++ b/include/Domain.h
@@ -13,7 +13,7 @@ class Domain : public DomainGrid {
 private:
   DomainParameters domainParameters;
 
-  ReadParam param;
+  ReadParam readParam;
 
   ParticleTrackerInfo ptInfo;
 

--- a/include/Domain.h
+++ b/include/Domain.h
@@ -11,8 +11,6 @@
 
 class Domain : public DomainGrid {
 private:
-  // Shared, rarely-changing configuration. Declared before the dependent
-  // objects (fi/pic/pt/source) so it always outlives them.
   DomainParameters domainParameters;
 
   ReadParam param;
@@ -27,9 +25,9 @@ public:
   // Q: Why are pic and pt defined as pointers?
   // A: Pic and particleTracker are derived from AmrCore, whose initialization
   // requires the informaion of the domain, such as the domain range and cell
-  // size. Such information is not known untill Domain received information from
+  // size. Such information is not known until Domain received information from
   // GM and read the input parameters. pic and pt are used as pointers so that
-  // their initialization is defered until the grid information is obtained.
+  // their initialization is deferred until the grid information is obtained.
   std::unique_ptr<Pic> pic;
   std::unique_ptr<ParticleTracker> pt;
 
@@ -88,8 +86,7 @@ public:
   //--------------- IO begin--------------------------------
   void read_param(const bool readGridInfo);
 
-  // Parse Domain-level switches before constructing children; caller rolls
-  // back.
+  // Parse Domain-level switches before constructing children, then roll back.
   void read_domain_parameters(ReadParam &param);
   void save_restart(std::string restartOutDir);
   void save_restart_header();

--- a/include/Domain.h
+++ b/include/Domain.h
@@ -87,6 +87,13 @@ public:
 
   //--------------- IO begin--------------------------------
   void read_param(const bool readGridInfo);
+
+  // Pre-pass: parse the Domain-level configuration (restart/init/source/PT
+  // toggles and load-balance settings) into parameters_ so that child
+  // components can be constructed gated on the correct values (e.g. usePT
+  // gates the ParticleTracker, useSource gates the source object). The stream
+  // is left mid-file; callers must roll_back() afterward.
+  void read_domain_parameters(ReadParam &param);
   void save_restart(std::string restartOutDir);
   void save_restart_header();
   void save_restart_data();

--- a/include/Domain.h
+++ b/include/Domain.h
@@ -2,6 +2,7 @@
 #define _DOMAIN_H_
 
 #include "DomainGrid.h"
+#include "DomainParameters.h"
 #include "OHInterface.h"
 #include "ParticleTracker.h"
 #include "Pic.h"
@@ -10,24 +11,11 @@
 
 class Domain : public DomainGrid {
 private:
-  bool doRestart = false;
-
-  bool doRestartPT = false;
-
-  bool doRestartFIOnly = false;
+  // Shared, rarely-changing configuration. Declared before the dependent
+  // objects (fi/pic/pt/source) so it always outlives them.
+  DomainParameters parameters_;
 
   ReadParam param;
-
-  // Number of files per AMREX output.
-  int nFileField = 64, nFileParticle = 256;
-
-  bool initFromSWMF = true;
-
-  bool receiveICOnly = false;
-
-  bool usePT = false;
-
-  bool useSource = false;
 
   ParticleTrackerInfo ptInfo;
 
@@ -118,7 +106,7 @@ public:
   // void make_data();
   void init_time_ctr();
 
-  bool receive_ic_only() { return receiveICOnly; };
+  bool receive_ic_only() { return parameters_.receiveICOnly; };
 };
 
 #endif

--- a/include/Domain.h
+++ b/include/Domain.h
@@ -13,7 +13,7 @@ class Domain : public DomainGrid {
 private:
   // Shared, rarely-changing configuration. Declared before the dependent
   // objects (fi/pic/pt/source) so it always outlives them.
-  DomainParameters parameters_;
+  DomainParameters domainParameters;
 
   ReadParam param;
 
@@ -88,11 +88,8 @@ public:
   //--------------- IO begin--------------------------------
   void read_param(const bool readGridInfo);
 
-  // Pre-pass: parse the Domain-level configuration (restart/init/source/PT
-  // toggles and load-balance settings) into parameters_ so that child
-  // components can be constructed gated on the correct values (e.g. usePT
-  // gates the ParticleTracker, useSource gates the source object). The stream
-  // is left mid-file; callers must roll_back() afterward.
+  // Parse Domain-level switches before constructing children; caller rolls
+  // back.
   void read_domain_parameters(ReadParam &param);
   void save_restart(std::string restartOutDir);
   void save_restart_header();
@@ -113,7 +110,7 @@ public:
   // void make_data();
   void init_time_ctr();
 
-  bool receive_ic_only() { return parameters_.receiveICOnly; };
+  bool receive_ic_only() { return domainParameters.receiveICOnly; };
 };
 
 #endif

--- a/include/DomainGrid.h
+++ b/include/DomainGrid.h
@@ -69,9 +69,6 @@ protected:
   bool isNewGrid = true;
   bool isNewRefinement = false;
 
-  BalanceStrategy balanceStrategy = BalanceStrategy::Cell;
-  int cellWeight = 10;
-
   bool doSplitLevs = false;
 
 public:

--- a/include/DomainParameters.h
+++ b/include/DomainParameters.h
@@ -3,12 +3,8 @@
 
 #include "FleksDistributionMap.h"
 
-// Shared, rarely-changing configuration for a FLEKS Domain.
-//
-// Owned privately by Domain (see Domain.h); only Domain mutates it, via
-// Domain::read_param(). Children (pic/pt/fi/source) never own or copy it.
-// Future step: inject a narrow const reference into the consumers that need a
-// slice, instead of reaching through Domain.
+// Rarely-changing configuration for a FLEKS Domain, owned by Domain and
+// shared (by const reference) with its child components.
 struct DomainParameters {
   // Restart control.
   bool doRestart = false;

--- a/include/DomainParameters.h
+++ b/include/DomainParameters.h
@@ -3,8 +3,8 @@
 
 #include "FleksDistributionMap.h"
 
-// Rarely-changing configuration for a FLEKS Domain, owned by Domain and
-// shared (by const reference) with its child components.
+// Configuration for a FLEKS Domain, owned by Domain and shared
+// with its child components.
 struct DomainParameters {
   // Restart control.
   bool doRestart = false;

--- a/include/DomainParameters.h
+++ b/include/DomainParameters.h
@@ -1,0 +1,35 @@
+#ifndef _DOMAINPARAMETERS_H_
+#define _DOMAINPARAMETERS_H_
+
+#include "FleksDistributionMap.h"
+
+// Shared, rarely-changing configuration for a FLEKS Domain.
+//
+// Owned privately by Domain (see Domain.h); only Domain mutates it, via
+// Domain::read_param(). Children (pic/pt/fi/source) never own or copy it.
+// Future step: inject a narrow const reference into the consumers that need a
+// slice, instead of reaching through Domain.
+struct DomainParameters {
+  // Restart control.
+  bool doRestart = false;
+  bool doRestartPT = false;
+  bool doRestartFIOnly = false;
+
+  // Coupling / initialization mode.
+  bool initFromSWMF = true;
+  bool receiveICOnly = false;
+
+  // Component toggles; gate child construction in Domain::init().
+  bool usePT = false;
+  bool useSource = false;
+
+  // Number of files per AMReX output.
+  int nFileField = 64;
+  int nFileParticle = 256;
+
+  // Load-balancing strategy.
+  BalanceStrategy balanceStrategy = BalanceStrategy::Cell;
+  int cellWeight = 10;
+};
+
+#endif // _DOMAINPARAMETERS_H_

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -1,6 +1,8 @@
 #ifndef _FLUIDINTERFACE_H_
 #define _FLUIDINTERFACE_H_
 
+#include <memory>
+
 #include <AMReX_Box.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_DistributionMapping.H>
@@ -19,7 +21,6 @@
 #include "GridUtility.h"
 #include "MDArray.h"
 #include "ReadParam.h"
-#include <memory>
 
 // Normalization parameters.
 //
@@ -33,7 +34,7 @@ public:
   void calc_normalization_units();
 
   double rPlanetSi = 1;
-  int    ScalingFactor = 1;
+  int ScalingFactor = 1;
 
   // normalization units for length, velocity, mass and charge
   // Normalized q/m == 1 for proton in CGS units
@@ -336,7 +337,9 @@ public:
   // return MhdNo2SiL
   double get_MhdNo2SiL() const { return (normParams->MhdNo2SiL); }
   // BATSRUS normalized unit -> PIC normalized unit;
-  double get_MhdNo2NoL() const { return (normParams->MhdNo2SiL * normParams->Si2NoL); }
+  double get_MhdNo2NoL() const {
+    return (normParams->MhdNo2SiL * normParams->Si2NoL);
+  }
 
   void sum_boundary() {
     timing_func("FI::sum_boundary");

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -24,7 +24,7 @@
 
 // Immutable SI<->normalized conversion factors, computed once from a
 // FluidInterface and shared read-only (shared_ptr<const>) by all interfaces.
-class FluidInterface;  // forward declaration; defined later in this header
+class FluidInterface; // forward declaration; defined later in this header
 
 class NormalizationParams {
 public:
@@ -117,6 +117,12 @@ protected:
 
   int iJx, iJy, iJz;
 
+  // Normalization base scalars, read from SWMF iParam/norm or from
+  // #NORMALIZATION/#SCALINGFACTOR/#BODYSIZE. Declared here so secondary
+  // interfaces (UserSource, OHInterface) inherit fi's finalized values.
+  double lNormSI = 1.0, uNormSI = 1.0, mNormSI = 1.0;
+  double rPlanetSi = 1.0, ScalingFactor = 1.0, MhdNo2SiL = 1.0;
+
   // Shared, FROZEN normalization / conversion parameters.  Owned and published
   // by the primary FluidInterface (fi) via finalize_normalization(); secondary
   // interfaces (UserSource, OHInterface) share fi's instance through the
@@ -170,11 +176,6 @@ protected:
 
   amrex::Vector<amrex::MultiFab> nodeFluid;
   amrex::Vector<amrex::MultiFab> centerB;
-
-  // Normalization base scalars, read from SWMF iParam/norm or from
-  // #NORMALIZATION/#SCALINGFACTOR/#BODYSIZE.
-  double lNormSI = 1.0, uNormSI = 1.0, mNormSI = 1.0;
-  double rPlanetSi = 1.0, ScalingFactor = 1.0, MhdNo2SiL = 1.0;
 
   bool isnodeFluidReady = false;
 

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -22,23 +22,26 @@
 #include "MDArray.h"
 #include "ReadParam.h"
 
-// Normalization parameters.
-//
-// Derived solely from variables in FluidInterface.
-// The fi interface owns the instance and freezes it.
-// UserSource, OHInterface share fi's instance via a shared_ptr.
+// Immutable SI<->normalized conversion factors, computed once from a
+// FluidInterface and shared read-only (shared_ptr<const>) by all interfaces.
+class FluidInterface;  // forward declaration; defined later in this header
+
 class NormalizationParams {
 public:
   NormalizationParams() = default;
+  // Build the derived normalization from fi.
+  NormalizationParams(const FluidInterface& fi, bool scalarOnly = false);
 
-  void calc_normalization_units();
+  // Derived temperature conversions.
+  double si2noT() const { return Si2NoL / Si2NoV; }
+  double no2siT() const { return Si2NoV / Si2NoL; }
 
   double rPlanetSi = 1;
   int ScalingFactor = 1;
 
   // normalization units for length, velocity, mass and charge
   // Normalized q/m == 1 for proton in CGS units
-  double Lnorm = 1, Unorm = 1, lNormSI = 1, uNormSI = 1;
+  double Lnorm = 1, Unorm = 1, uNormSI = 1;
   double Mnorm = 0, Qnorm = 0, mNormSI = 0;
 
   amrex::Vector<double> Si2No_V, No2Si_V;
@@ -48,6 +51,10 @@ public:
 
   // Length in BATSRUS normalized unit -> Si
   double MhdNo2SiL = 1;
+
+private:
+  void calc_normalization_units(double lNormSI, double uNormSI, double mNormSI);
+  void compute_var_conversions(const FluidInterface& fi);
 };
 
 class FluidInterfaceParameters {
@@ -110,13 +117,13 @@ protected:
 
   int iJx, iJy, iJz;
 
-  // Shared normalization / conversion parameters.  Owned by the primary
-  // FluidInterface (fi); secondary interfaces (UserSource, OHInterface) share
-  // fi's instance via the defaulted copy constructor, so they always read the
-  // finalized values after fi->post_process_param() -- no slice sync or
-  // stale-copy is possible.
-  std::shared_ptr<NormalizationParams> normParams =
-      std::make_shared<NormalizationParams>();
+  // Shared, FROZEN normalization / conversion parameters.  Owned and published
+  // by the primary FluidInterface (fi) via finalize_normalization(); secondary
+  // interfaces (UserSource, OHInterface) share fi's instance through the
+  // FluidInterfaceParameters copy constructor and MUST NOT mutate it (it is a
+  // shared_ptr<const>).
+  std::shared_ptr<const NormalizationParams> normParams =
+      std::make_shared<const NormalizationParams>();
 
   amrex::Vector<double> uniformState;
 
@@ -149,6 +156,8 @@ public:
 };
 
 class FluidInterface : public Grid, public FluidInterfaceParameters {
+  // NormalizationParams is a derived, immutable snapshot of fi's parameters.
+  friend class NormalizationParams;
   /*
   Q: It is preferable to declare copyable variables in
     FluidInterfaceParameters. Why?
@@ -161,6 +170,11 @@ protected:
 
   amrex::Vector<amrex::MultiFab> nodeFluid;
   amrex::Vector<amrex::MultiFab> centerB;
+
+  // Normalization base scalars, read from SWMF iParam/norm or from
+  // #NORMALIZATION/#SCALINGFACTOR/#BODYSIZE.
+  double lNormSI = 1.0, uNormSI = 1.0, mNormSI = 1.0;
+  double rPlanetSi = 1.0, ScalingFactor = 1.0, MhdNo2SiL = 1.0;
 
   bool isnodeFluidReady = false;
 
@@ -250,9 +264,12 @@ public:
 
   void set_plasma_charge_and_mass(amrex::Real qomEl);
 
-  void calc_normalization_units();
-
-  void calc_conversion_units();
+  // Compute all derived normalization + per-variable conversion factors and
+  // publish an immutable instance into normParams. When scalarOnly is true only
+  // the scalar SI<->normalized factors are derived (used for the early
+  // "initial-condition-only" publish before variable indices are known);
+  // otherwise the per-variable conversion vectors are filled as well.
+  void finalize_normalization(bool scalarOnly = false);
 
   void analyze_var_names(bool useNeutral = false);
 
@@ -303,28 +320,18 @@ public:
   int get_nFluid() const { return nFluid; }
 
   const amrex::Vector<std::string>& get_var_names() const { return varNames; }
-  double get_Si2No_V(int idx) const { return (normParams->Si2No_V[idx]); }
+
+  // Named accessors for the frozen normalization state. They present a stable,
+  // self-documenting API; callers must not reach into the NormalizationParams
+  // object directly. The instance is shared read-only with all secondary
+  // interfaces.
   double get_Si2NoL() const { return (normParams->Si2NoL); }
-  double get_Si2NoT() const { return normParams->Si2NoL / normParams->Si2NoV; }
-  double get_Si2NoM() const { return 1. / normParams->mNormSI; }
+  double get_Si2NoM() const { return (1. / normParams->mNormSI); }
   double get_Si2NoRho() const { return normParams->Si2NoRho; }
   double get_Si2NoV() const { return normParams->Si2NoV; }
   double get_Si2NoP() const { return normParams->Si2NoP; }
 
-  double get_No2Si_V(int idx) const { return (normParams->No2Si_V[idx]); }
-  double get_No2SiL() const { return (normParams->No2SiL); }
-  double get_No2SiRho() const { return (1. / normParams->Si2NoRho); }
-  double get_No2SiV() const { return (1. / normParams->Si2NoV); }
-  double get_No2SiB() const { return (1. / normParams->Si2NoB); }
-  double get_No2SiP() const { return (1. / normParams->Si2NoP); }
-  double get_No2SiJ() const { return (1. / normParams->Si2NoJ); }
-  double get_No2SiT() const { return normParams->Si2NoV / normParams->Si2NoL; }
-  double get_No2SiM() const { return normParams->mNormSI; }
-
-  double get_species_mass(int i) const { return MoMi_S[i]; };
-  double get_species_charge(int i) const { return QoQi_S[i]; };
-
-  double get_lnorm_si() const { return normParams->lNormSI; }
+  double get_lnorm_si() const { return lNormSI; }
   double get_unorm_si() const { return normParams->uNormSI; }
   double get_mnorm_si() const { return normParams->mNormSI; };
 
@@ -334,9 +341,25 @@ public:
 
   int get_scaling_factor() const { return normParams->ScalingFactor; }
 
-  // return MhdNo2SiL
   double get_MhdNo2SiL() const { return (normParams->MhdNo2SiL); }
-  // BATSRUS normalized unit -> PIC normalized unit;
+
+  double get_Si2No_V(int idx) const { return normParams->Si2No_V[idx]; }
+
+  double get_No2Si_V(int idx) const { return normParams->No2Si_V[idx]; }
+  double get_No2SiL() const { return (normParams->No2SiL); }
+  double get_No2SiRho() const { return (1. / normParams->Si2NoRho); }
+  double get_No2SiV() const { return (1. / normParams->Si2NoV); }
+  double get_No2SiB() const { return (1. / normParams->Si2NoB); }
+  double get_No2SiP() const { return (1. / normParams->Si2NoP); }
+  double get_No2SiJ() const { return (1. / normParams->Si2NoJ); }
+  double get_No2SiM() const { return normParams->mNormSI; }
+
+  double get_species_mass(int i) const { return MoMi_S[i]; };
+  double get_species_charge(int i) const { return QoQi_S[i]; };
+
+  // Derived temperature + MHD-length conversions.
+  double get_Si2NoT() const { return normParams->si2noT(); }
+  double get_No2SiT() const { return normParams->no2siT(); }
   double get_MhdNo2NoL() const {
     return (normParams->MhdNo2SiL * normParams->Si2NoL);
   }

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -181,6 +181,18 @@ public:
         static_cast<const FluidInterfaceParameters&>(other);
   }
 
+  // Refresh ONLY the normalization-related parameters from another
+  // FluidInterface and recompute the normalization units.  Unlike
+  // sync_fluid_interface_params(), this does NOT copy nS / MoMi_S / QoQi_S /
+  // varNames / iRho_I, so it is safe for secondary interfaces (OHInterface)
+  // whose constructors deliberately reset those members.  Used by Domain for
+  // the OH-PT stateOH / sourcePT2OH grids, which are copy-constructed from
+  // *fi *before* fi->post_process_param() finalizes the derived normalization
+  // (mNormSI, rPlanetSi override).  Without this, stateOH->get_Si2NoRho() etc.
+  // would reflect a stale mNormSI / rPlanetSi and produce a wrong OH-PT charge
+  // exchange rate.
+  void sync_normalization_params(const FluidInterface& other);
+
   void set_period_start_si(double t) { tStartSI = t; }
 
   double get_period_start_si() const { return tStartSI; }

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -19,6 +19,42 @@
 #include "GridUtility.h"
 #include "MDArray.h"
 #include "ReadParam.h"
+#include <memory>
+
+// Shared normalization / conversion parameters.
+//
+// These quantities are derived solely from lNormSI / uNormSI / mNormSI /
+// rPlanetSi (set in FluidInterface::read_param / post_process_param) and are
+// frozen once the *primary* FluidInterface (fi) calls post_process_param().
+//
+// Secondary interfaces (UserSource, OHInterface) do NOT copy these values;
+// they hold a shared_ptr to fi's NormalizationParams instance.  Because the
+// pointer is shared, the secondary interfaces automatically observe fi's
+// finalized values after post_process_param() -- no slice-sync or stale-copy
+// is possible.  This replaces the previous sync_fluid_interface_params /
+// sync_normalization_params pattern and removes the stale-copy class of bugs.
+class NormalizationParams {
+public:
+  NormalizationParams() = default;
+
+  void calc_normalization_units();
+
+  double rPlanetSi = 1;
+  int    ScalingFactor = 1;
+
+  // normalization units for length, velocity, mass and charge
+  // Normalized q/m == 1 for proton in CGS units
+  double Lnorm = 1, Unorm = 1, lNormSI = 1, uNormSI = 1;
+  double Mnorm = 0, Qnorm = 0, mNormSI = 0;
+
+  amrex::Vector<double> Si2No_V, No2Si_V;
+  double Si2NoM = 0, Si2NoV = 0, Si2NoRho = 0, Si2NoB = 0, Si2NoP = 0,
+         Si2NoJ = 0, Si2NoL = 0, Si2NoE = 0;
+  double No2SiV = 0, No2SiL = 0;
+
+  // Length in BATSRUS normalized unit -> Si
+  double MhdNo2SiL = 1;
+};
 
 class FluidInterfaceParameters {
 protected:
@@ -80,23 +116,15 @@ protected:
 
   int iJx, iJy, iJz;
 
-  double rPlanetSi = 1;
-
-  int ScalingFactor = 1;
-
-  // normalization units for length, velocity, mass and charge
-  // Normalized q/m ==1 for proton in CGS units
-  double Lnorm, Unorm, lNormSI = 1, uNormSI = 1;
-  double Mnorm, Qnorm, mNormSI;
-
-  amrex::Vector<double> Si2No_V, No2Si_V;
-  double Si2NoM, Si2NoV, Si2NoRho, Si2NoB, Si2NoP, Si2NoJ, Si2NoL, Si2NoE;
-  double No2SiV, No2SiL;
+  // Shared normalization / conversion parameters.  Owned by the primary
+  // FluidInterface (fi); secondary interfaces (UserSource, OHInterface) share
+  // fi's instance via the defaulted copy constructor, so they always read the
+  // finalized values after fi->post_process_param() -- no slice sync or
+  // stale-copy is possible.
+  std::shared_ptr<NormalizationParams> normParams =
+      std::make_shared<NormalizationParams>();
 
   amrex::Vector<double> uniformState;
-
-  // Length in BATSRUS normalized unit -> Si
-  double MhdNo2SiL;
 
   bool useResist = false;
   double etaSI = 0, etaNO = 0;
@@ -180,18 +208,6 @@ public:
     static_cast<FluidInterfaceParameters&>(*this) =
         static_cast<const FluidInterfaceParameters&>(other);
   }
-
-  // Refresh ONLY the normalization-related parameters from another
-  // FluidInterface and recompute the normalization units.  Unlike
-  // sync_fluid_interface_params(), this does NOT copy nS / MoMi_S / QoQi_S /
-  // varNames / iRho_I, so it is safe for secondary interfaces (OHInterface)
-  // whose constructors deliberately reset those members.  Used by Domain for
-  // the OH-PT stateOH / sourcePT2OH grids, which are copy-constructed from
-  // *fi *before* fi->post_process_param() finalizes the derived normalization
-  // (mNormSI, rPlanetSi override).  Without this, stateOH->get_Si2NoRho() etc.
-  // would reflect a stale mNormSI / rPlanetSi and produce a wrong OH-PT charge
-  // exchange rate.
-  void sync_normalization_params(const FluidInterface& other);
 
   void set_period_start_si(double t) { tStartSI = t; }
 
@@ -293,41 +309,41 @@ public:
   int get_nFluid() const { return nFluid; }
 
   const amrex::Vector<std::string>& get_var_names() const { return varNames; }
-  double get_Si2No_V(int idx) const { return (Si2No_V[idx]); }
-  double get_Si2NoL() const { return (Si2NoL); }
-  double get_Si2NoT() const { return Si2NoL / Si2NoV; }
-  double get_Si2NoM() const { return 1. / mNormSI; }
-  double get_Si2NoRho() const { return Si2NoRho; }
-  double get_Si2NoV() const { return Si2NoV; }
-  double get_Si2NoP() const { return Si2NoP; }
+  double get_Si2No_V(int idx) const { return (normParams->Si2No_V[idx]); }
+  double get_Si2NoL() const { return (normParams->Si2NoL); }
+  double get_Si2NoT() const { return normParams->Si2NoL / normParams->Si2NoV; }
+  double get_Si2NoM() const { return 1. / normParams->mNormSI; }
+  double get_Si2NoRho() const { return normParams->Si2NoRho; }
+  double get_Si2NoV() const { return normParams->Si2NoV; }
+  double get_Si2NoP() const { return normParams->Si2NoP; }
 
-  double get_No2Si_V(int idx) const { return (No2Si_V[idx]); }
-  double get_No2SiL() const { return (No2SiL); }
-  double get_No2SiRho() const { return (1. / Si2NoRho); }
-  double get_No2SiV() const { return (1. / Si2NoV); }
-  double get_No2SiB() const { return (1. / Si2NoB); }
-  double get_No2SiP() const { return (1. / Si2NoP); }
-  double get_No2SiJ() const { return (1. / Si2NoJ); }
-  double get_No2SiT() const { return Si2NoV / Si2NoL; }
-  double get_No2SiM() const { return mNormSI; }
+  double get_No2Si_V(int idx) const { return (normParams->No2Si_V[idx]); }
+  double get_No2SiL() const { return (normParams->No2SiL); }
+  double get_No2SiRho() const { return (1. / normParams->Si2NoRho); }
+  double get_No2SiV() const { return (1. / normParams->Si2NoV); }
+  double get_No2SiB() const { return (1. / normParams->Si2NoB); }
+  double get_No2SiP() const { return (1. / normParams->Si2NoP); }
+  double get_No2SiJ() const { return (1. / normParams->Si2NoJ); }
+  double get_No2SiT() const { return normParams->Si2NoV / normParams->Si2NoL; }
+  double get_No2SiM() const { return normParams->mNormSI; }
 
   double get_species_mass(int i) const { return MoMi_S[i]; };
   double get_species_charge(int i) const { return QoQi_S[i]; };
 
-  double get_lnorm_si() const { return lNormSI; }
-  double get_unorm_si() const { return uNormSI; }
-  double get_mnorm_si() const { return mNormSI; };
+  double get_lnorm_si() const { return normParams->lNormSI; }
+  double get_unorm_si() const { return normParams->uNormSI; }
+  double get_mnorm_si() const { return normParams->mNormSI; };
 
-  double get_cLight_SI() const { return uNormSI; }
+  double get_cLight_SI() const { return normParams->uNormSI; }
 
-  double get_rPlanet_SI() const { return rPlanetSi; }
+  double get_rPlanet_SI() const { return normParams->rPlanetSi; }
 
-  int get_scaling_factor() const { return ScalingFactor; }
+  int get_scaling_factor() const { return normParams->ScalingFactor; }
 
   // return MhdNo2SiL
-  double get_MhdNo2SiL() const { return (MhdNo2SiL); }
+  double get_MhdNo2SiL() const { return (normParams->MhdNo2SiL); }
   // BATSRUS normalized unit -> PIC normalized unit;
-  double get_MhdNo2NoL() const { return (MhdNo2SiL * Si2NoL); }
+  double get_MhdNo2NoL() const { return (normParams->MhdNo2SiL * normParams->Si2NoL); }
 
   void sum_boundary() {
     timing_func("FI::sum_boundary");
@@ -363,7 +379,7 @@ public:
     etaSI = etaSIIn;
     useResist = etaSI > 0;
     if (useResist)
-      etaNO = fourPI * etaSI * Si2NoV * Si2NoL;
+      etaNO = fourPI * etaSI * normParams->Si2NoV * normParams->Si2NoL;
   }
 
   void set_ohm_u(std::string ss) {

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -21,18 +21,11 @@
 #include "ReadParam.h"
 #include <memory>
 
-// Shared normalization / conversion parameters.
+// Normalization parameters.
 //
-// These quantities are derived solely from lNormSI / uNormSI / mNormSI /
-// rPlanetSi (set in FluidInterface::read_param / post_process_param) and are
-// frozen once the *primary* FluidInterface (fi) calls post_process_param().
-//
-// Secondary interfaces (UserSource, OHInterface) do NOT copy these values;
-// they hold a shared_ptr to fi's NormalizationParams instance.  Because the
-// pointer is shared, the secondary interfaces automatically observe fi's
-// finalized values after post_process_param() -- no slice-sync or stale-copy
-// is possible.  This replaces the previous sync_fluid_interface_params /
-// sync_normalization_params pattern and removes the stale-copy class of bugs.
+// Derived solely from variables in FluidInterface.
+// The fi interface owns the instance and freezes it.
+// UserSource, OHInterface share fi's instance via a shared_ptr.
 class NormalizationParams {
 public:
   NormalizationParams() = default;

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -170,6 +170,17 @@ public:
 
   FluidType my_type() { return myType; };
 
+  // Copy the FluidInterfaceParameters slice from another FluidInterface.
+  // Used by Domain to keep the source / test-particle grids' parameters in
+  // sync with the primary fluid interface: they are copy-constructed from
+  // *fi before read_param populates *fi, so their snapshot is stale until
+  // this sync runs.  Only the FluidInterfaceParameters members are copied;
+  // the Grid data and SourceInterface / UserSource members are preserved.
+  void sync_fluid_interface_params(const FluidInterface& other) {
+    static_cast<FluidInterfaceParameters&>(*this) =
+        static_cast<const FluidInterfaceParameters&>(other);
+  }
+
   void set_period_start_si(double t) { tStartSI = t; }
 
   double get_period_start_si() const { return tStartSI; }

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -37,21 +37,15 @@ public:
   double si2noT() const { return Si2NoL / Si2NoV; }
   double no2siT() const { return Si2NoV / Si2NoL; }
 
-  double rPlanetSi = 1;
-  int ScalingFactor = 1;
-
   // normalization units for length, velocity, mass and charge
   // Normalized q/m == 1 for proton in CGS units
-  double Lnorm = 1, Unorm = 1, uNormSI = 1;
-  double Mnorm = 0, Qnorm = 0, mNormSI = 0;
+  double Lnorm = 1, Unorm = 1;
+  double Mnorm = 0, Qnorm = 0;
 
   amrex::Vector<double> Si2No_V, No2Si_V;
   double Si2NoM = 0, Si2NoV = 0, Si2NoRho = 0, Si2NoB = 0, Si2NoP = 0,
          Si2NoJ = 0, Si2NoL = 0, Si2NoE = 0;
   double No2SiV = 0, No2SiL = 0;
-
-  // Length in BATSRUS normalized unit -> Si
-  double MhdNo2SiL = 1;
 
 private:
   void calc_normalization_units(double lNormSI, double uNormSI, double mNormSI);
@@ -124,8 +118,7 @@ protected:
   int iJx, iJy, iJz;
 
   // Normalization base scalars, read from SWMF iParam/norm or from
-  // #NORMALIZATION/#SCALINGFACTOR/#BODYSIZE. Declared here so secondary
-  // interfaces (UserSource, OHInterface) inherit fi's finalized values.
+  // #NORMALIZATION/#SCALINGFACTOR/#BODYSIZE.
   double lNormSI = 1.0, uNormSI = 1.0, mNormSI = 1.0;
   double rPlanetSi = 1.0, ScalingFactor = 1.0, MhdNo2SiL = 1.0;
 
@@ -322,22 +315,22 @@ public:
 
   // Read-only accessors for the shared, frozen normalization state.
   double get_Si2NoL() const { return (normParams->Si2NoL); }
-  double get_Si2NoM() const { return (1. / normParams->mNormSI); }
+  double get_Si2NoM() const { return (1. / mNormSI); }
   double get_Si2NoRho() const { return normParams->Si2NoRho; }
   double get_Si2NoV() const { return normParams->Si2NoV; }
   double get_Si2NoP() const { return normParams->Si2NoP; }
 
   double get_lnorm_si() const { return lNormSI; }
-  double get_unorm_si() const { return normParams->uNormSI; }
-  double get_mnorm_si() const { return normParams->mNormSI; };
+  double get_unorm_si() const { return uNormSI; }
+  double get_mnorm_si() const { return mNormSI; };
 
-  double get_cLight_SI() const { return normParams->uNormSI; }
+  double get_cLight_SI() const { return uNormSI; }
 
-  double get_rPlanet_SI() const { return normParams->rPlanetSi; }
+  double get_rPlanet_SI() const { return rPlanetSi; }
 
-  int get_scaling_factor() const { return normParams->ScalingFactor; }
+  int get_scaling_factor() const { return ScalingFactor; }
 
-  double get_MhdNo2SiL() const { return (normParams->MhdNo2SiL); }
+  double get_MhdNo2SiL() const { return (MhdNo2SiL); }
 
   double get_Si2No_V(int idx) const { return normParams->Si2No_V[idx]; }
 
@@ -348,7 +341,7 @@ public:
   double get_No2SiB() const { return (1. / normParams->Si2NoB); }
   double get_No2SiP() const { return (1. / normParams->Si2NoP); }
   double get_No2SiJ() const { return (1. / normParams->Si2NoJ); }
-  double get_No2SiM() const { return normParams->mNormSI; }
+  double get_No2SiM() const { return mNormSI; }
 
   double get_species_mass(int i) const { return MoMi_S[i]; };
   double get_species_charge(int i) const { return QoQi_S[i]; };
@@ -356,9 +349,7 @@ public:
   // Derived temperature + MHD-length conversions.
   double get_Si2NoT() const { return normParams->si2noT(); }
   double get_No2SiT() const { return normParams->no2siT(); }
-  double get_MhdNo2NoL() const {
-    return (normParams->MhdNo2SiL * normParams->Si2NoL);
-  }
+  double get_MhdNo2NoL() const { return (MhdNo2SiL * normParams->Si2NoL); }
 
   void sum_boundary() {
     timing_func("FI::sum_boundary");

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -123,11 +123,7 @@ protected:
   double lNormSI = 1.0, uNormSI = 1.0, mNormSI = 1.0;
   double rPlanetSi = 1.0, ScalingFactor = 1.0, MhdNo2SiL = 1.0;
 
-  // Shared, FROZEN normalization / conversion parameters.  Owned and published
-  // by the primary FluidInterface (fi) via finalize_normalization(); secondary
-  // interfaces (UserSource, OHInterface) share fi's instance through the
-  // FluidInterfaceParameters copy constructor and MUST NOT mutate it (it is a
-  // shared_ptr<const>).
+  // Read-only once published; changable via finalize_normalization().
   std::shared_ptr<const NormalizationParams> normParams =
       std::make_shared<const NormalizationParams>();
 
@@ -265,11 +261,7 @@ public:
 
   void set_plasma_charge_and_mass(amrex::Real qomEl);
 
-  // Compute all derived normalization + per-variable conversion factors and
-  // publish an immutable instance into normParams. When scalarOnly is true only
-  // the scalar SI<->normalized factors are derived (used for the early
-  // "initial-condition-only" publish before variable indices are known);
-  // otherwise the per-variable conversion vectors are filled as well.
+  // Publish the immutable normParams; scalarOnly skips per-variable factors.
   void finalize_normalization(bool scalarOnly = false);
 
   void analyze_var_names(bool useNeutral = false);
@@ -322,10 +314,7 @@ public:
 
   const amrex::Vector<std::string>& get_var_names() const { return varNames; }
 
-  // Named accessors for the frozen normalization state. They present a stable,
-  // self-documenting API; callers must not reach into the NormalizationParams
-  // object directly. The instance is shared read-only with all secondary
-  // interfaces.
+  // Read-only accessors for the shared, frozen normalization state.
   double get_Si2NoL() const { return (normParams->Si2NoL); }
   double get_Si2NoM() const { return (1. / normParams->mNormSI); }
   double get_Si2NoRho() const { return normParams->Si2NoRho; }

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -17,6 +17,7 @@
 #include <AMReX_VisMF.H>
 
 #include "Constants.h"
+#include "DomainParameters.h"
 #include "Grid.h"
 #include "GridUtility.h"
 #include "MDArray.h"
@@ -227,7 +228,7 @@ public:
 
   void read_param(const std::string& command, ReadParam& param);
 
-  void post_process_param(bool receiveICOnly = false);
+  void post_process_param(const DomainParameters &parameters);
 
   void set_var_idx();
 

--- a/include/FluidInterface.h
+++ b/include/FluidInterface.h
@@ -228,7 +228,7 @@ public:
 
   void read_param(const std::string& command, ReadParam& param);
 
-  void post_process_param(const DomainParameters &parameters);
+  void post_process_param(const DomainParameters& parameters);
 
   void set_var_idx();
 

--- a/include/OHInterface.h
+++ b/include/OHInterface.h
@@ -22,7 +22,6 @@ public:
     }
 
     varNames.clear();
-    calc_normalization_units();
   };
 
   virtual int get_neu_source_region(const amrex::MFIter &mfi,

--- a/include/OHInterface.h
+++ b/include/OHInterface.h
@@ -23,10 +23,11 @@ public:
 
     varNames.clear();
 
-    // Shares fi's frozen normalization instance via the FluidInterfaceParameters
-    // copy constructor. fi re-derives its normalization from explicit
-    // #NORMALIZATION base values (when present) in Domain::read_param, so this
-    // is always consistent with fi -- no silent detach required.
+    // Shares fi's frozen normalization instance via the
+    // FluidInterfaceParameters copy constructor. fi re-derives its
+    // normalization from explicit #NORMALIZATION base values (when present) in
+    // Domain::read_param, so this is always consistent with fi -- no silent
+    // detach required.
   };
 
   virtual int get_neu_source_region(const amrex::MFIter &mfi,

--- a/include/OHInterface.h
+++ b/include/OHInterface.h
@@ -23,19 +23,13 @@ public:
 
     varNames.clear();
 
-    // Restore pre-refactor (master) OH<->PT normalization behavior so the
-    // output matches the existing test20 reference.  In the parameter-loading
-    // redesign, secondary interfaces (incl. OHInterface) were made to share
-    // fi's normParams.  For SWMF OH-PT runs, fi's Si2No_* are computed
-    // from the SWMF-supplied base values inside the FluidInterface ctor, but
-    // the PT component PARAM.in then re-specifies those base values via
-    // #NORMALIZATION in read_param(); because post_process_param() early-
-    // returns in SWMF mode, fi's Si2No_* are never recomputed.  master's
-    // OHInterface ctor re-derived its own normalization here (from fi's
-    // parameters at construction time, i.e. after #NORMALIZATION), which is
-    // exactly what the test20 reference was generated with.  We reproduce
-    // that, but first detach from the shared normParams (deep copy) so the
-    // recompute does not mutate fi's normalization.
+    // TODO: In SWMF OH-PT mode fi->post_process_param() early-returns, so the
+    // #NORMALIZATION base values from the PT PARAM.in are never applied to fi.
+    // We detach and re-derive our own normalization here only to reproduce the
+    // test20 reference -- this silent divergence from fi's normalization is
+    // fragile and may be physically inconsistent. Investigate unifying fi's and
+    // OH's normalization so both reflect the same base values instead of this
+    // deep-copy workaround.
     normParams = std::make_shared<NormalizationParams>(*normParams);
     normParams->calc_normalization_units();
   };

--- a/include/OHInterface.h
+++ b/include/OHInterface.h
@@ -22,6 +22,22 @@ public:
     }
 
     varNames.clear();
+
+    // Restore pre-refactor (master) OH<->PT normalization behavior so the
+    // output matches the existing test20 reference.  In the parameter-loading
+    // redesign, secondary interfaces (incl. OHInterface) were made to share
+    // fi's normParams.  For SWMF OH-PT runs, fi's Si2No_* are computed
+    // from the SWMF-supplied base values inside the FluidInterface ctor, but
+    // the PT component PARAM.in then re-specifies those base values via
+    // #NORMALIZATION in read_param(); because post_process_param() early-
+    // returns in SWMF mode, fi's Si2No_* are never recomputed.  master's
+    // OHInterface ctor re-derived its own normalization here (from fi's
+    // parameters at construction time, i.e. after #NORMALIZATION), which is
+    // exactly what the test20 reference was generated with.  We reproduce
+    // that, but first detach from the shared normParams (deep copy) so the
+    // recompute does not mutate fi's normalization.
+    normParams = std::make_shared<NormalizationParams>(*normParams);
+    normParams->calc_normalization_units();
   };
 
   virtual int get_neu_source_region(const amrex::MFIter &mfi,

--- a/include/OHInterface.h
+++ b/include/OHInterface.h
@@ -23,15 +23,10 @@ public:
 
     varNames.clear();
 
-    // TODO: In SWMF OH-PT mode fi->post_process_param() early-returns, so the
-    // #NORMALIZATION base values from the PT PARAM.in are never applied to fi.
-    // We detach and re-derive our own normalization here only to reproduce the
-    // test20 reference -- this silent divergence from fi's normalization is
-    // fragile and may be physically inconsistent. Investigate unifying fi's and
-    // OH's normalization so both reflect the same base values instead of this
-    // deep-copy workaround.
-    normParams = std::make_shared<NormalizationParams>(*normParams);
-    normParams->calc_normalization_units();
+    // Shares fi's frozen normalization instance via the FluidInterfaceParameters
+    // copy constructor. fi re-derives its normalization from explicit
+    // #NORMALIZATION base values (when present) in Domain::read_param, so this
+    // is always consistent with fi -- no silent detach required.
   };
 
   virtual int get_neu_source_region(const amrex::MFIter &mfi,

--- a/include/OHInterface.h
+++ b/include/OHInterface.h
@@ -22,12 +22,6 @@ public:
     }
 
     varNames.clear();
-
-    // Shares fi's frozen normalization instance via the
-    // FluidInterfaceParameters copy constructor. fi re-derives its
-    // normalization from explicit #NORMALIZATION base values (when present) in
-    // Domain::read_param, so this is always consistent with fi -- no silent
-    // detach required.
   };
 
   virtual int get_neu_source_region(const amrex::MFIter &mfi,

--- a/include/ParticleTracker.h
+++ b/include/ParticleTracker.h
@@ -53,7 +53,6 @@ private:
   // ParticleTrackerInfo::post_process_param (after fi is fully processed).
   ParticleTrackerInfo* pInfo = nullptr;
 
-  int nSpecies = 0;
   amrex::Vector<std::unique_ptr<TestParticles> > parts;
   amrex::Vector<amrex::MultiFab> nodeE;
 

--- a/include/ParticleTracker.h
+++ b/include/ParticleTracker.h
@@ -4,16 +4,19 @@
 #include <AMReX_Vector.H>
 
 #include "Grid.h"
+#include "Particles.h"
 #include "Pic.h"
 #include "TestParticles.h"
-#include "Particles.h"
 
 class ParticleTracker : public Grid {
 public:
   ParticleTracker(amrex::Geometry const &gm, amrex::AmrInfo const &amrInfo,
                   int nGst, FluidInterface *fluidIn, TimeCtr *tcIn, int id,
-                  ParticleTrackerInfo& info)
-      : Grid(gm, amrInfo, nGst, id, "pt"), tc(tcIn), fi(fluidIn), pInfo(&info) {}
+                  ParticleTrackerInfo &info)
+      : Grid(gm, amrInfo, nGst, id, "pt"),
+        tc(tcIn),
+        fi(fluidIn),
+        pInfo(&info) {}
 
   ~ParticleTracker() {
     if (isNewGrid)
@@ -51,7 +54,7 @@ private:
 
   // Parameter container populated by Domain during read_param and resolved in
   // ParticleTrackerInfo::post_process_param (after fi is fully processed).
-  ParticleTrackerInfo* pInfo = nullptr;
+  ParticleTrackerInfo *pInfo = nullptr;
 
   amrex::Vector<std::unique_ptr<TestParticles> > parts;
   amrex::Vector<amrex::MultiFab> nodeE;

--- a/include/ParticleTracker.h
+++ b/include/ParticleTracker.h
@@ -6,16 +6,14 @@
 #include "Grid.h"
 #include "Pic.h"
 #include "TestParticles.h"
+#include "Particles.h"
 
 class ParticleTracker : public Grid {
 public:
   ParticleTracker(amrex::Geometry const &gm, amrex::AmrInfo const &amrInfo,
-                  int nGst, FluidInterface *fluidIn, TimeCtr *tcIn, int id)
-      : Grid(gm, amrInfo, nGst, id, "pt"), tc(tcIn), fi(fluidIn) {
-    nSpecies = fi->get_nS();
-    dnSave.resize(nSpecies, 10);
-    launchThreshold.resize(nSpecies, 0.5);
-  };
+                  int nGst, FluidInterface *fluidIn, TimeCtr *tcIn, int id,
+                  ParticleTrackerInfo& info)
+      : Grid(gm, amrInfo, nGst, id, "pt"), tc(tcIn), fi(fluidIn), pInfo(&info) {}
 
   ~ParticleTracker() {
     if (isNewGrid)
@@ -43,7 +41,6 @@ public:
   void save_restart_data();
   void save_restart_header(std::ofstream &headerFile);
   void read_restart();
-  void read_param(const std::string &command, ReadParam &param);
   void write_log(bool doForce = false, bool doCreateFile = false);
 
   void set_tp_init_shapes(amrex::Vector<std::shared_ptr<Shape> > &shapes);
@@ -52,34 +49,21 @@ private:
   TimeCtr *tc = nullptr;
   FluidInterface *fi = nullptr;
 
-  int nSpecies;
+  // Parameter container populated by Domain during read_param and resolved in
+  // ParticleTrackerInfo::post_process_param (after fi is fully processed).
+  ParticleTrackerInfo* pInfo = nullptr;
+
+  int nSpecies = 0;
   amrex::Vector<std::unique_ptr<TestParticles> > parts;
   amrex::Vector<amrex::MultiFab> nodeE;
 
   amrex::Vector<amrex::MultiFab> nodeB;
 
-  amrex::Vector<unsigned long int> initPartNumber;
-
   std::unique_ptr<PlotCtr> savectr;
-  amrex::Vector<int> dnSave;
-  amrex::Vector<amrex::Real> launchThreshold;
-
-  amrex::IntVect nTPPerCell = { AMREX_D_DECL(1, 1, 1) };
-  amrex::IntVect nTPIntervalCell = { AMREX_D_DECL(1, 1, 1) };
-
-  std::string sIOUnit = "planet";
-
-  bool isRelativistic = false;
-
-  amrex::Vector<std::string> listFiles;
-  bool doInitFromPIC = false;
-
-  amrex::Vector<Vel> tpStates;
 
   std::string logFile;
 
-  // Test Particle initialization regions
-  std::string sRegion;
+  // Test Particle initialization regions (set from the domain #REGION blocks).
   amrex::Vector<std::shared_ptr<Shape> > tpShapes;
 };
 

--- a/include/ParticleTracker.h
+++ b/include/ParticleTracker.h
@@ -12,10 +12,11 @@ class ParticleTracker : public Grid {
 public:
   ParticleTracker(amrex::Geometry const &gm, amrex::AmrInfo const &amrInfo,
                   int nGst, FluidInterface *fluidIn, TimeCtr *tcIn, int id,
-                  ParticleTrackerInfo &info)
+                  ParticleTrackerInfo &info, const DomainParameters &dp)
       : Grid(gm, amrInfo, nGst, id, "pt"),
         tc(tcIn),
         fi(fluidIn),
+        parameters_(dp),
         pInfo(&info) {}
 
   ~ParticleTracker() {
@@ -51,6 +52,10 @@ public:
 private:
   TimeCtr *tc = nullptr;
   FluidInterface *fi = nullptr;
+
+  // Non-owning reference to Domain's shared, rarely-changing configuration.
+  // Domain always out-lives ParticleTracker, so a reference is safe.
+  const DomainParameters &parameters_;
 
   // Parameter container populated by Domain during read_param and resolved in
   // ParticleTrackerInfo::post_process_param (after fi is fully processed).

--- a/include/ParticleTracker.h
+++ b/include/ParticleTracker.h
@@ -16,7 +16,7 @@ public:
       : Grid(gm, amrInfo, nGst, id, "pt"),
         tc(tcIn),
         fi(fluidIn),
-        parameters_(dp),
+        domainParameters(dp),
         pInfo(&info) {}
 
   ~ParticleTracker() {
@@ -53,9 +53,7 @@ private:
   TimeCtr *tc = nullptr;
   FluidInterface *fi = nullptr;
 
-  // Non-owning reference to Domain's shared, rarely-changing configuration.
-  // Domain always out-lives ParticleTracker, so a reference is safe.
-  const DomainParameters &parameters_;
+  const DomainParameters &domainParameters;
 
   // Parameter container populated by Domain during read_param and resolved in
   // ParticleTrackerInfo::post_process_param (after fi is fully processed).

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -117,6 +117,149 @@ public:
   const BC& particle_bc(const int speciesID) const { return pBCs[speciesID]; }
 };
 
+//===========================================================================
+/// Parameter container for the test-particle (ParticleTracker) component.
+///
+/// All of the #TP* / #TESTPARTICLENUMBER settings previously lived as plain
+/// members of the Grid-derived ParticleTracker object and were therefore
+/// snapshotted in its constructor -- before the number of species (read by
+/// #PLASMA into FluidInterface) was known.  That premature snapshot made
+/// standalone test-particle setups unusable (nSpecies was read as 0).
+///
+/// Collecting those parameters here decouples "what is configured" from the
+/// heavy AMReX Grid object, exactly as ParticlesInfo already does for Pic.
+/// Domain parses the #TP* commands into this object during read_param, and
+/// ParticleTracker reads its settings back from it.  Species-dependent
+/// quantities (dnSave / launchThreshold sizes, velocity-unit conversion) are
+/// resolved in post_process_param(), which is called only after fi has been
+/// fully processed.
+//===========================================================================
+class ParticleTrackerInfo {
+public:
+  amrex::IntVect nTPPerCell = {AMREX_D_DECL(1, 1, 1)};
+  amrex::IntVect nTPIntervalCell = {AMREX_D_DECL(1, 1, 1)};
+
+  std::string sIOUnit = "planet";
+  bool isRelativistic = false;
+
+  amrex::Vector<std::string> listFiles;
+  bool doInitFromPIC = false;
+
+  // Test-particle velocity states.  Optionally given in SI units and
+  // converted to normalized units during read_param() via fi->get_Si2NoV().
+  amrex::Vector<Vel> tpStates;
+
+  std::string sRegion = "";
+
+  // Sized to the number of species in post_process_param(); filled by #TPSAVE.
+  amrex::Vector<int> dnSave;
+  amrex::Vector<amrex::Real> launchThreshold;
+
+  // Per-species particle counts used by restart (#TESTPARTICLENUMBER).
+  amrex::Vector<unsigned long int> initPartNumber;
+
+  void set_fluid_interface(FluidInterface* in) { fi = in; }
+
+  void read_param(const std::string& command, ReadParam& param) {
+    if (command == "#TPPARTICLES") {
+      param.read_var("npcelx", nTPPerCell[ix_]);
+      param.read_var("npcely", nTPPerCell[iy_]);
+      if (nDim == 3) param.read_var("npcelz", nTPPerCell[iz_]);
+    } else if (command == "#TPCELLINTERVAL") {
+      param.read_var("nIntervalX", nTPIntervalCell[ix_]);
+      param.read_var("nIntervalY", nTPIntervalCell[iy_]);
+      if (nDim == 3) param.read_var("nIntervalZ", nTPIntervalCell[iz_]);
+    } else if (command == "#TPREGION") {
+      param.read_var("region", sRegion);
+    } else if (command == "#TPSAVE") {
+      int iSpecies;
+      param.read_var("iSpecies", iSpecies);
+      if (iSpecies < 0)
+        amrex::Abort("Error [ParticleTrackerInfo]: iSpecies must be >= 0 in #TPSAVE.");
+      // Defer the final bounds check against nSpecies to post_process_param();
+      // grow the vectors here so #TPSAVE may appear before #PLASMA.
+      if (iSpecies >= (int)dnSave.size())
+        dnSave.resize(iSpecies + 1, 10);
+      if (iSpecies >= (int)launchThreshold.size())
+        launchThreshold.resize(iSpecies + 1, 0.5);
+      param.read_var("IOUnit", sIOUnit);
+      param.read_var("dnSave", dnSave[iSpecies]);
+      param.read_var("launchThreshold", launchThreshold[iSpecies]);
+    } else if (command == "#TPRELATIVISTIC") {
+      param.read_var("isRelativistic", isRelativistic);
+    } else if (command == "#TPSTATESI") {
+      if (!fi)
+        amrex::Abort("Error [ParticleTrackerInfo]: #TPSTATESI requires a FluidInterface to be set.");
+      double si2noV = fi->get_Si2NoV();
+      int nState;
+      param.read_var("nState", nState);
+      tpStates.clear();
+      tpStates.reserve(nState);
+      for (int i = 0; i < nState; ++i) {
+        Vel state;
+        param.read_var("iSpecies", state.tag);
+        param.read_var("vth", state.vth);
+        param.read_var("vx", state.vx);
+        param.read_var("vy", state.vy);
+        param.read_var("vz", state.vz);
+        state.vth *= si2noV;
+        state.vx *= si2noV;
+        state.vy *= si2noV;
+        state.vz *= si2noV;
+        tpStates.push_back(state);
+      }
+    } else if (command == "#TPINITFROMPIC") {
+      param.read_var("doInitFromPIC", doInitFromPIC);
+      if (doInitFromPIC) {
+        int nList;
+        param.read_var("nList", nList);
+        listFiles.clear();
+        listFiles.reserve(nList);
+        for (int i = 0; i < nList; ++i) {
+          std::string s;
+          param.read_var("list", s);
+          listFiles.push_back(s);
+        }
+      }
+    } else if (command == "#TESTPARTICLENUMBER") {
+      initPartNumber.clear();
+      int nS = fi ? fi->get_nS() : 0;
+      for (int iPart = 0; iPart < nS; iPart++) {
+        unsigned long int num;
+        param.read_var("Number", num);
+        initPartNumber.push_back(num);
+      }
+    }
+  }
+
+  // Resolve species-dependent quantities.  MUST be called after fi has been
+  // fully processed (fi->post_process_param) so fi->get_nS() is final.
+  void post_process_param() {
+    if (!fi)
+      amrex::Abort("Error [ParticleTrackerInfo]: post_process_param called before the FluidInterface was set.");
+    const int nS = fi->get_nS();
+
+    if (dnSave.empty()) {
+      dnSave.assign(nS, 10);
+    } else if ((int)dnSave.size() < nS) {
+      dnSave.resize(nS, 10);
+    } else if ((int)dnSave.size() > nS) {
+      amrex::Abort("Error [ParticleTrackerInfo]: #TPSAVE iSpecies exceeds the number of species.");
+    }
+
+    if (launchThreshold.empty()) {
+      launchThreshold.assign(nS, 0.5);
+    } else if ((int)launchThreshold.size() < nS) {
+      launchThreshold.resize(nS, 0.5);
+    } else if ((int)launchThreshold.size() > nS) {
+      amrex::Abort("Error [ParticleTrackerInfo]: #TPSAVE iSpecies exceeds the number of species.");
+    }
+  }
+
+private:
+  FluidInterface* fi = nullptr;
+};
+
 template <int NStructReal, int NStructInt>
 class ParticlesIter : public amrex::ParIter<NStructReal, NStructInt> {
 public:

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -120,19 +120,10 @@ public:
 //===========================================================================
 /// Parameter container for the test-particle (ParticleTracker) component.
 ///
-/// All of the #TP* / #TESTPARTICLENUMBER settings previously lived as plain
-/// members of the Grid-derived ParticleTracker object and were therefore
-/// snapshotted in its constructor -- before the number of species (read by
-/// #PLASMA into FluidInterface) was known.  That premature snapshot made
-/// standalone test-particle setups unusable (nSpecies was read as 0).
-///
-/// Collecting those parameters here decouples "what is configured" from the
-/// heavy AMReX Grid object, exactly as ParticlesInfo already does for Pic.
-/// Domain parses the #TP* commands into this object during read_param, and
-/// ParticleTracker reads its settings back from it.  Species-dependent
-/// quantities (dnSave / launchThreshold sizes, velocity-unit conversion) are
-/// resolved in post_process_param(), which is called only after fi has been
-/// fully processed.
+/// Holds all test particle settings parsed by Domain during read_param();
+/// ParticleTracker reads its configuration back from this object.
+/// Species-dependent quantities (dnSave / launchThreshold sizes, velocity-unit
+/// conversion) are resolved in post_process_param(), called processing fi.
 //===========================================================================
 class ParticleTrackerInfo {
 public:

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -127,8 +127,8 @@ public:
 //===========================================================================
 class ParticleTrackerInfo {
 public:
-  amrex::IntVect nTPPerCell = {AMREX_D_DECL(1, 1, 1)};
-  amrex::IntVect nTPIntervalCell = {AMREX_D_DECL(1, 1, 1)};
+  amrex::IntVect nTPPerCell = { AMREX_D_DECL(1, 1, 1) };
+  amrex::IntVect nTPIntervalCell = { AMREX_D_DECL(1, 1, 1) };
 
   std::string sIOUnit = "planet";
   bool isRelativistic = false;
@@ -155,18 +155,21 @@ public:
     if (command == "#TPPARTICLES") {
       param.read_var("npcelx", nTPPerCell[ix_]);
       param.read_var("npcely", nTPPerCell[iy_]);
-      if (nDim == 3) param.read_var("npcelz", nTPPerCell[iz_]);
+      if (nDim == 3)
+        param.read_var("npcelz", nTPPerCell[iz_]);
     } else if (command == "#TPCELLINTERVAL") {
       param.read_var("nIntervalX", nTPIntervalCell[ix_]);
       param.read_var("nIntervalY", nTPIntervalCell[iy_]);
-      if (nDim == 3) param.read_var("nIntervalZ", nTPIntervalCell[iz_]);
+      if (nDim == 3)
+        param.read_var("nIntervalZ", nTPIntervalCell[iz_]);
     } else if (command == "#TPREGION") {
       param.read_var("region", sRegion);
     } else if (command == "#TPSAVE") {
       int iSpecies;
       param.read_var("iSpecies", iSpecies);
       if (iSpecies < 0)
-        amrex::Abort("Error [ParticleTrackerInfo]: iSpecies must be >= 0 in #TPSAVE.");
+        amrex::Abort(
+            "Error [ParticleTrackerInfo]: iSpecies must be >= 0 in #TPSAVE.");
       // Defer the final bounds check against nSpecies to post_process_param();
       // grow the vectors here so #TPSAVE may appear before #PLASMA.
       if (iSpecies >= (int)dnSave.size())
@@ -180,7 +183,8 @@ public:
       param.read_var("isRelativistic", isRelativistic);
     } else if (command == "#TPSTATESI") {
       if (!fi)
-        amrex::Abort("Error [ParticleTrackerInfo]: #TPSTATESI requires a FluidInterface to be set.");
+        amrex::Abort("Error [ParticleTrackerInfo]: #TPSTATESI requires a "
+                     "FluidInterface to be set.");
       double si2noV = fi->get_Si2NoV();
       int nState;
       param.read_var("nState", nState);
@@ -227,7 +231,8 @@ public:
   // fully processed (fi->post_process_param) so fi->get_nS() is final.
   void post_process_param() {
     if (!fi)
-      amrex::Abort("Error [ParticleTrackerInfo]: post_process_param called before the FluidInterface was set.");
+      amrex::Abort("Error [ParticleTrackerInfo]: post_process_param called "
+                   "before the FluidInterface was set.");
     const int nS = fi->get_nS();
 
     if (dnSave.empty()) {
@@ -235,7 +240,8 @@ public:
     } else if ((int)dnSave.size() < nS) {
       dnSave.resize(nS, 10);
     } else if ((int)dnSave.size() > nS) {
-      amrex::Abort("Error [ParticleTrackerInfo]: #TPSAVE iSpecies exceeds the number of species.");
+      amrex::Abort("Error [ParticleTrackerInfo]: #TPSAVE iSpecies exceeds the "
+                   "number of species.");
     }
 
     if (launchThreshold.empty()) {
@@ -243,7 +249,8 @@ public:
     } else if ((int)launchThreshold.size() < nS) {
       launchThreshold.resize(nS, 0.5);
     } else if ((int)launchThreshold.size() > nS) {
-      amrex::Abort("Error [ParticleTrackerInfo]: #TPSAVE iSpecies exceeds the number of species.");
+      amrex::Abort("Error [ParticleTrackerInfo]: #TPSAVE iSpecies exceeds the "
+                   "number of species.");
     }
   }
 

--- a/include/Particles.h
+++ b/include/Particles.h
@@ -122,8 +122,7 @@ public:
 ///
 /// Holds all test particle settings parsed by Domain during read_param();
 /// ParticleTracker reads its configuration back from this object.
-/// Species-dependent quantities (dnSave / launchThreshold sizes, velocity-unit
-/// conversion) are resolved in post_process_param(), called processing fi.
+/// Species-dependent quantities are resolved in post_process_param().
 //===========================================================================
 class ParticleTrackerInfo {
 public:

--- a/include/Pic.h
+++ b/include/Pic.h
@@ -64,6 +64,10 @@ private:
   SourceInterface *source = nullptr;
   TimeCtr *tc = nullptr;
 
+  // Non-owning reference to Domain's shared, rarely-changing configuration.
+  // Domain always out-lives Pic, so a reference (not a copy) is safe.
+  const DomainParameters &parameters_;
+
   amrex::Vector<amrex::MultiFab> nodeE;
   amrex::Vector<amrex::MultiFab> nodeEth;
   amrex::Vector<amrex::MultiFab> nodeB;
@@ -166,8 +170,10 @@ private:
   // public methods
 public:
   Pic(amrex::Geometry const &gm, amrex::AmrInfo const &amrInfo, int nGst,
-      FluidInterface *fluidIn, TimeCtr *tcIn, int id = 0)
-      : Grid(gm, amrInfo, nGst, id, "pic"), fi(fluidIn), tc(tcIn) {
+      FluidInterface *fluidIn, TimeCtr *tcIn, int id,
+      const DomainParameters &parameters)
+      : Grid(gm, amrInfo, nGst, id, "pic"), fi(fluidIn), tc(tcIn),
+        parameters_(parameters) {
     eSolver.set_tol(1e-6);
     eSolver.set_nIter(200);
 
@@ -336,7 +342,7 @@ public:
   void report_load_balance(bool doReportSummary = true,
                            bool doReportDetail = false);
 
-  void calc_cost_per_cell(const DomainParameters &parameters);
+  void calc_cost_per_cell();
 
   void convert_1d_to_3d(const double *const p, amrex::MultiFab &MF, int iLev);
 

--- a/include/Pic.h
+++ b/include/Pic.h
@@ -6,6 +6,7 @@
 #include "Array1D.h"
 #include "Bit.h"
 #include "Constants.h"
+#include "DomainParameters.h"
 #include "FleksDistributionMap.h"
 #include "FluidInterface.h"
 #include "Grid.h"
@@ -335,8 +336,7 @@ public:
   void report_load_balance(bool doReportSummary = true,
                            bool doReportDetail = false);
 
-  void calc_cost_per_cell(BalanceStrategy balanceStrategy,
-                          int cellWeight = 100);
+  void calc_cost_per_cell(const DomainParameters &parameters);
 
   void convert_1d_to_3d(const double *const p, amrex::MultiFab &MF, int iLev);
 

--- a/include/Pic.h
+++ b/include/Pic.h
@@ -64,9 +64,7 @@ private:
   SourceInterface *source = nullptr;
   TimeCtr *tc = nullptr;
 
-  // Non-owning reference to Domain's shared, rarely-changing configuration.
-  // Domain always out-lives Pic, so a reference (not a copy) is safe.
-  const DomainParameters &parameters_;
+  const DomainParameters &domainParameters;
 
   amrex::Vector<amrex::MultiFab> nodeE;
   amrex::Vector<amrex::MultiFab> nodeEth;
@@ -172,8 +170,10 @@ public:
   Pic(amrex::Geometry const &gm, amrex::AmrInfo const &amrInfo, int nGst,
       FluidInterface *fluidIn, TimeCtr *tcIn, int id,
       const DomainParameters &parameters)
-      : Grid(gm, amrInfo, nGst, id, "pic"), fi(fluidIn), tc(tcIn),
-        parameters_(parameters) {
+      : Grid(gm, amrInfo, nGst, id, "pic"),
+        fi(fluidIn),
+        tc(tcIn),
+        domainParameters(parameters) {
     eSolver.set_tol(1e-6);
     eSolver.set_nIter(200);
 

--- a/include/SourceInterface.h
+++ b/include/SourceInterface.h
@@ -88,10 +88,14 @@ protected:
   // Allocated whenever useRecombination or useChemistry is true.
   amrex::Vector<amrex::MultiFab> nodeLossFluid;
 
+  // Non-owning reference to Domain's shared, rarely-changing configuration.
+  // Domain always out-lives the source, so a reference is safe.
+  const DomainParameters &parameters_;
+
 public:
   SourceInterface(const FluidInterface& other, int id, std::string tag,
-                  FluidType typeIn = SourceFluid)
-      : FluidInterface(other, id, tag, typeIn) {
+                 FluidType typeIn, const DomainParameters &dp)
+      : FluidInterface(other, id, tag, typeIn), parameters_(dp) {
     initFromSWMF = false;
   }
 

--- a/include/SourceInterface.h
+++ b/include/SourceInterface.h
@@ -88,14 +88,12 @@ protected:
   // Allocated whenever useRecombination or useChemistry is true.
   amrex::Vector<amrex::MultiFab> nodeLossFluid;
 
-  // Non-owning reference to Domain's shared, rarely-changing configuration.
-  // Domain always out-lives the source, so a reference is safe.
-  const DomainParameters &parameters_;
+  const DomainParameters& domainParameters;
 
 public:
   SourceInterface(const FluidInterface& other, int id, std::string tag,
-                 FluidType typeIn, const DomainParameters &dp)
-      : FluidInterface(other, id, tag, typeIn), parameters_(dp) {
+                  FluidType typeIn, const DomainParameters& dp)
+      : FluidInterface(other, id, tag, typeIn), domainParameters(dp) {
     initFromSWMF = false;
   }
 

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -1253,6 +1253,22 @@ void Domain::read_param(const bool readGridInfo) {
     if (source)
       source->post_process_param();
 
+    // OH-PT secondary interfaces (stateOH / sourcePT2OH) are copy-constructed
+    // from *fi *before* fi->post_process_param() finalizes the derived
+    // normalization (mNormSI, rPlanetSi override).  Their OHInterface
+    // constructors re-derive the normalization units immediately at
+    // construction (i.e. from stale mNormSI / rPlanetSi), so refresh only the
+    // normalization parameters now that fi's are final.  This is intentionally
+    // NOT a full sync_fluid_interface_params(): OHInterface's nS / MoMi_S /
+    // QoQi_S / varNames / iRho_I are managed separately (constructor resets
+    // and set_node_fluid -> analyze_var_names) and must not be clobbered.
+#ifdef _PT_COMPONENT_
+    if (stateOH)
+      stateOH->sync_normalization_params(*fi);
+    if (sourcePT2OH)
+      sourcePT2OH->sync_normalization_params(*fi);
+#endif
+
     if (pt) {
       // Resolve species-dependent quantities (dnSave / launchThreshold
       // sizes) only after fi has been fully processed, then refresh the

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -42,6 +42,7 @@ void Domain::init(double time, const int iDomain,
 
   if (receiveICOnly) {
     fi = std::make_unique<FluidInterface>(gm, amrInfo, nGst, gridID, "fi");
+    ptInfo.set_fluid_interface(fi.get());
     read_param(false);
 
     gridInfo.init(nCell[ix_], nCell[iy_], nCell[iz_], fi->get_nCellPerPatch());
@@ -58,11 +59,12 @@ void Domain::init(double time, const int iDomain,
     fi = std::make_unique<FluidInterface>(gm, amrInfo, nGst, gridID, "fi");
   }
 
+  ptInfo.set_fluid_interface(fi.get());
   pic = std::make_unique<Pic>(gm, amrInfo, nGst, fi.get(), tc.get(), gridID);
 
   if (usePT)
     pt = std::make_unique<ParticleTracker>(gm, amrInfo, nGst, fi.get(),
-                                           tc.get(), gridID);
+                                           tc.get(), gridID, ptInfo);
 
   // Create the source object before read_param so that ionization
   // commands (#PHOTOIONIZATION, #ELECTRONIMPACT, #CHARGEEXCHANGE)
@@ -897,13 +899,12 @@ void Domain::read_param(const bool readGridInfo) {
         command == "#MEMORY") {
       if (pic)
         pic->read_param(command, param);
-    } else if (command == "#TESTPARTICLENUMBER" || command == "#TPPARTICLES" ||
-               command == "#TPCELLINTERVAL" || command == "#TPREGION" ||
-               command == "#TPSAVE" || command == "#TPRELATIVISTIC" ||
-               command == "#TPINITFROMPIC" || command == "#TPSTATESI") {
-      if (pt)
-        pt->read_param(command, param);
-    } else if (command == "#PHOTOIONIZATION" || command == "#ELECTRONIMPACT" ||
+  } else if (command == "#TESTPARTICLENUMBER" || command == "#TPPARTICLES" ||
+             command == "#TPCELLINTERVAL" || command == "#TPREGION" ||
+             command == "#TPSAVE" || command == "#TPRELATIVISTIC" ||
+             command == "#TPINITFROMPIC" || command == "#TPSTATESI") {
+    ptInfo.read_param(command, param);
+  } else if (command == "#PHOTOIONIZATION" || command == "#ELECTRONIMPACT" ||
                command == "#CHARGEEXCHANGE" || command == "#SHADOWCYLINDER" ||
                command == "#RECOMBINATION" || command == "#CHEMISTRY") {
       if (source) {
@@ -1232,11 +1233,6 @@ void Domain::read_param(const bool readGridInfo) {
     if (pic)
       pic->post_process_param();
 
-    if (pt) {
-      pt->post_process_param();
-      pt->set_tp_init_shapes(shapes);
-    }
-
     if (fi)
       fi->post_process_param(receiveICOnly);
 
@@ -1250,6 +1246,15 @@ void Domain::read_param(const bool readGridInfo) {
 
     if (source)
       source->post_process_param();
+
+    if (pt) {
+      // Resolve species-dependent quantities (dnSave / launchThreshold
+      // sizes) only after fi has been fully processed, then refresh the
+      // tracker so it no longer relies on any constructor-time snapshot.
+      ptInfo.post_process_param();
+      pt->post_process_param();
+      pt->set_tp_init_shapes(shapes);
+    }
   }
 
   VisMF::SetNOutFiles(nFileField);

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -900,23 +900,19 @@ void Domain::read_param(const bool readGridInfo) {
         command == "#MEMORY") {
       if (pic)
         pic->read_param(command, param);
-  } else if (command == "#TESTPARTICLENUMBER" || command == "#TPPARTICLES" ||
-             command == "#TPCELLINTERVAL" || command == "#TPREGION" ||
-             command == "#TPSAVE" || command == "#TPRELATIVISTIC" ||
-             command == "#TPINITFROMPIC" || command == "#TPSTATESI") {
-    ptInfo.read_param(command, param);
-  } else if (command == "#PHOTOIONIZATION" || command == "#ELECTRONIMPACT" ||
+    } else if (command == "#TESTPARTICLENUMBER" || command == "#TPPARTICLES" ||
+               command == "#TPCELLINTERVAL" || command == "#TPREGION" ||
+               command == "#TPSAVE" || command == "#TPRELATIVISTIC" ||
+               command == "#TPINITFROMPIC" || command == "#TPSTATESI") {
+      ptInfo.read_param(command, param);
+    } else if (command == "#PHOTOIONIZATION" || command == "#ELECTRONIMPACT" ||
                command == "#CHARGEEXCHANGE" || command == "#SHADOWCYLINDER" ||
                command == "#RECOMBINATION" || command == "#CHEMISTRY") {
       if (source) {
-        // The source grid is copy-constructed from *fi before read_param
-        // populates *fi, so its neutral/plasma parameters are a stale
-        // snapshot.  Synchronize them from fi ONCE, just before the first
-        // ionization command is parsed.  By the (required) convention
-        // #EXOSPHERE and #PLASMA precede the ionization commands, fi's
-        // nExoComponent / nS / etc. are already final at this point.  Only
-        // the FluidInterfaceParameters slice is copied; SourceInterface
-        // members (e.g. cxSigma) are preserved.
+        // Sync source's FluidInterfaceParameters from fi ONCE, just before the
+        // first ionization command. By convention #EXOSPHERE/#PLASMA precede
+        // the ionization commands, so fi's nExoComponent / nS are already
+        // final; SourceInterface members (e.g. cxSigma) are preserved.
         if (!sourceParamsSynced) {
           source->sync_fluid_interface_params(*fi);
           sourceParamsSynced = true;
@@ -1240,13 +1236,10 @@ void Domain::read_param(const bool readGridInfo) {
     if (fi)
       fi->post_process_param(receiveICOnly);
 
-    // Synchronize source's parameters from fi one final time, now that
+    // Final sync of source's FluidInterfaceParameters from fi, now that
     // fi->post_process_param() has finalized the derived arrays (MoMi_S,
-    // QoQi_S, iRho_I, Si2NoRho, Si2NoP, ...).  This makes source->post_
-    // process_param() and base FluidInterface methods (e.g.
-    // convert_moment_to_velocity) operate on correct, locally-owned data.
-    // The lazy one-time sync above handled the read_param-phase reads
-    // (nExoComponent / nS set by #EXOSPHERE / #PLASMA).
+    // QoQi_S, iRho_I, Si2NoRho, Si2NoP, ...), so source->post_process_param()
+    // and base FluidInterface methods use correct, locally-owned data.
     if (source)
       source->sync_fluid_interface_params(*fi);
 
@@ -1254,9 +1247,8 @@ void Domain::read_param(const bool readGridInfo) {
       source->post_process_param();
 
     if (pt) {
-      // Resolve species-dependent quantities (dnSave / launchThreshold
-      // sizes) only after fi has been fully processed, then refresh the
-      // tracker so it no longer relies on any constructor-time snapshot.
+      // Resolve species-dependent sizes (dnSave / launchThreshold) now that
+      // fi is final, then refresh the tracker from the resolved config.
       ptInfo.post_process_param();
       pt->post_process_param();
       pt->set_tp_init_shapes(shapes);

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -853,6 +853,7 @@ void Domain::read_param(const bool readGridInfo) {
   std::string command;
 
   param.set_verbose(false);
+  bool sourceParamsSynced = false;
   param.set_command_suffix(gridName);
   param.set_component(component);
   while (param.get_next_command(command)) {
@@ -908,15 +909,18 @@ void Domain::read_param(const bool readGridInfo) {
                command == "#CHARGEEXCHANGE" || command == "#SHADOWCYLINDER" ||
                command == "#RECOMBINATION" || command == "#CHEMISTRY") {
       if (source) {
-        // Sync exosphere/plasma parameters from fi to source so that
-        // source->read_param() can access nExoComponent (set by #EXOSPHERE)
-        // and nS (set by #PLASMA) without each ionization command
-        // redundantly re-declaring the component count.  #EXOSPHERE and
-        // #PLASMA must therefore appear before the ionization commands in
-        // PARAM.in.  Only the FluidInterfaceParameters slice is copied;
-        // SourceInterface members (e.g. cxSigma) are preserved.
-        static_cast<FluidInterfaceParameters &>(*source) =
-            static_cast<const FluidInterfaceParameters &>(*fi);
+        // The source grid is copy-constructed from *fi before read_param
+        // populates *fi, so its neutral/plasma parameters are a stale
+        // snapshot.  Synchronize them from fi ONCE, just before the first
+        // ionization command is parsed.  By the (required) convention
+        // #EXOSPHERE and #PLASMA precede the ionization commands, fi's
+        // nExoComponent / nS / etc. are already final at this point.  Only
+        // the FluidInterfaceParameters slice is copied; SourceInterface
+        // members (e.g. cxSigma) are preserved.
+        if (!sourceParamsSynced) {
+          source->sync_fluid_interface_params(*fi);
+          sourceParamsSynced = true;
+        }
         source->read_param(command, param);
       }
     } else if (command == "#NORMALIZATION" || command == "#SCALINGFACTOR" ||
@@ -1236,13 +1240,15 @@ void Domain::read_param(const bool readGridInfo) {
     if (fi)
       fi->post_process_param(receiveICOnly);
 
-    // source was created before read_param with a stale copy of *fi.
-    // Copy the now-fully-populated FluidInterfaceParameters from fi to
-    // source so that source has correct exosphere, plasma, and
-    // normalization data.
+    // Synchronize source's parameters from fi one final time, now that
+    // fi->post_process_param() has finalized the derived arrays (MoMi_S,
+    // QoQi_S, iRho_I, Si2NoRho, Si2NoP, ...).  This makes source->post_
+    // process_param() and base FluidInterface methods (e.g.
+    // convert_moment_to_velocity) operate on correct, locally-owned data.
+    // The lazy one-time sync above handled the read_param-phase reads
+    // (nExoComponent / nS set by #EXOSPHERE / #PLASMA).
     if (source)
-      static_cast<FluidInterfaceParameters &>(*source) =
-          static_cast<const FluidInterfaceParameters &>(*fi);
+      source->sync_fluid_interface_params(*fi);
 
     if (source)
       source->post_process_param();

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -1253,22 +1253,6 @@ void Domain::read_param(const bool readGridInfo) {
     if (source)
       source->post_process_param();
 
-    // OH-PT secondary interfaces (stateOH / sourcePT2OH) are copy-constructed
-    // from *fi *before* fi->post_process_param() finalizes the derived
-    // normalization (mNormSI, rPlanetSi override).  Their OHInterface
-    // constructors re-derive the normalization units immediately at
-    // construction (i.e. from stale mNormSI / rPlanetSi), so refresh only the
-    // normalization parameters now that fi's are final.  This is intentionally
-    // NOT a full sync_fluid_interface_params(): OHInterface's nS / MoMi_S /
-    // QoQi_S / varNames / iRho_I are managed separately (constructor resets
-    // and set_node_fluid -> analyze_var_names) and must not be clobbered.
-#ifdef _PT_COMPONENT_
-    if (stateOH)
-      stateOH->sync_normalization_params(*fi);
-    if (sourcePT2OH)
-      sourcePT2OH->sync_normalization_params(*fi);
-#endif
-
     if (pt) {
       // Resolve species-dependent quantities (dnSave / launchThreshold
       // sizes) only after fi has been fully processed, then refresh the

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -18,15 +18,15 @@ void Domain::init(double time, const int iDomain,
   printPrefix = gridName + ": ";
 
 #ifdef _PT_COMPONENT_
-  parameters_.useSource = true;
+  domainParameters.useSource = true;
 #endif
 
   { // It looks like the file saving may crash if the size of a single file is
     // too large. The numbers 64 and 2048 are chosen empirically.
     const int nFileBase = 64;
     int np = floor(ParallelDescriptor::NProcs() / 2048.0) + 1;
-    parameters_.nFileField = np * nFileBase;
-    parameters_.nFileParticle = np * nFileBase * 4;
+    domainParameters.nFileField = np * nFileBase;
+    domainParameters.nFileParticle = np * nFileBase * 4;
   }
 
   param = paramString;
@@ -37,9 +37,7 @@ void Domain::init(double time, const int iDomain,
 
   prepare_grid_info(paramRegion);
 
-  // Pre-pass: finalize Domain-level configuration BEFORE constructing child
-  // components, so construction can be gated on the correct values
-  // (usePT gates the ParticleTracker; useSource/usePT gate the source).
+  // Read Domain-level switches, then rewind so read_param re-reads the file.
   {
     read_domain_parameters(param);
     param.roll_back();
@@ -48,7 +46,7 @@ void Domain::init(double time, const int iDomain,
   refineRegionsStr.resize(amrInfo.max_level + 1);
   refineRegions.resize(amrInfo.max_level + 1);
 
-  if (parameters_.receiveICOnly) {
+  if (domainParameters.receiveICOnly) {
     fi = std::make_unique<FluidInterface>(gm, amrInfo, nGst, gridID, "fi");
     ptInfo.set_fluid_interface(fi.get());
     read_param(false);
@@ -58,7 +56,7 @@ void Domain::init(double time, const int iDomain,
     return;
   }
 
-  if (parameters_.initFromSWMF && !parameters_.receiveICOnly) {
+  if (domainParameters.initFromSWMF && !domainParameters.receiveICOnly) {
     fi = std::make_unique<FluidInterface>(
         gm, amrInfo, nGst, gridID, "fi", paramInt,
         Vector<double>(paramRegion.begin() + 18, paramRegion.end()), paramComm);
@@ -68,19 +66,19 @@ void Domain::init(double time, const int iDomain,
   }
 
   ptInfo.set_fluid_interface(fi.get());
-  pic = std::make_unique<Pic>(gm, amrInfo, nGst, fi.get(), tc.get(),
-                                 gridID, parameters_);
+  pic = std::make_unique<Pic>(gm, amrInfo, nGst, fi.get(), tc.get(), gridID,
+                              domainParameters);
 
-  if (parameters_.usePT)
-    pt = std::make_unique<ParticleTracker>(gm, amrInfo, nGst, fi.get(),
-                                           tc.get(), gridID, ptInfo,
-                                           parameters_);
+  if (domainParameters.usePT)
+    pt =
+        std::make_unique<ParticleTracker>(gm, amrInfo, nGst, fi.get(), tc.get(),
+                                          gridID, ptInfo, domainParameters);
 
   // Create the source object before read_param so that ionization
   // commands (#PHOTOIONIZATION, #ELECTRONIMPACT, #CHARGEEXCHANGE)
   // can be dispatched to source->read_param().
   source = std::make_unique<UserSource>(*fi, gridID, "picSource", SourceFluid,
-                                       parameters_);
+                                        domainParameters);
 
   read_param(false);
 
@@ -101,7 +99,7 @@ void Domain::init(double time, const int iDomain,
 
   // #SOURCE command sets useSource during read_param; discard the
   // source object if user did not request a source.
-  if (!parameters_.useSource) {
+  if (!domainParameters.useSource) {
     source.reset();
   } else {
     amrex::Print() << source->get_info() << " is used for source" << std::endl;
@@ -124,7 +122,7 @@ void Domain::init(double time, const int iDomain,
 
   pic->init_source(*fi);
 
-  if (parameters_.doRestart) {
+  if (domainParameters.doRestart) {
     // Restoring the restart data before coupling with GM, because the PIC grid
     // may change again during coupling.
     read_restart();
@@ -231,7 +229,7 @@ void Domain::update() {
   // - GM-PC: called from set_state_var() at coupling intervals; fi is
   //   unchanged between couplings, so skip here.
   // - OH-PT: not applicable; charge_exchange() handles source terms.
-  if (source && !parameters_.initFromSWMF) {
+  if (source && !domainParameters.initFromSWMF) {
     source->set_source(*fi);
     source->sum_boundary();
     source->sum_loss_boundary();
@@ -268,7 +266,9 @@ void Domain::prepare_grid_info(const Vector<double> &info) {
   if (isFake2D)
     set_periodicity(iz_, true);
 
-  bool setGridFromSWMF = !parameters_.doRestart && parameters_.initFromSWMF && !parameters_.receiveICOnly;
+  bool setGridFromSWMF = !domainParameters.doRestart &&
+                         domainParameters.initFromSWMF &&
+                         !domainParameters.receiveICOnly;
 
   if (setGridFromSWMF) {
     // If restart, the grid info will be read from restart.H
@@ -446,12 +446,12 @@ void Domain::receive_grid_info(int *status) { gridInfo.set_status(status); }
 //========================================================
 void Domain::set_ic() {
 
-  if (parameters_.receiveICOnly)
+  if (domainParameters.receiveICOnly)
     return;
 
   // If it is restart, the values should have been restored before coupling
   // with GM. See Domain::init().
-  if (!(parameters_.doRestart && !parameters_.doRestartFIOnly)) {
+  if (!(domainParameters.doRestart && !domainParameters.doRestartFIOnly)) {
 
     fi->set_node_fluid();
 
@@ -461,7 +461,7 @@ void Domain::set_ic() {
     pic->write_log(true, true);
   }
 
-  if (!parameters_.doRestartPT) {
+  if (!domainParameters.doRestartPT) {
     if (pt)
       pt->set_ic(*pic);
 
@@ -484,7 +484,7 @@ void Domain::set_state_var(double *data, int *index,
   Print() << printPrefix << " " << sourceComp << " -> " << component
           << " coupling at t =" << tc->get_time_si() << " (s)" << std::endl;
 
-  if (parameters_.receiveICOnly) {
+  if (domainParameters.receiveICOnly) {
     fi->set_node_fluid(data, index, names);
     // For some cases, the variables information is not unknown until the first
     // couping is called.
@@ -609,7 +609,7 @@ void Domain::read_restart() {
   fi->regrid(grid.boxArray(0), &grid);
   fi->read_restart();
 
-  if (!parameters_.doRestartFIOnly) {
+  if (!domainParameters.doRestartFIOnly) {
     pic->regrid(grid.boxArray(0), fi.get());
 
     if (pt)
@@ -619,7 +619,7 @@ void Domain::read_restart() {
     write_plots(true);
     pic->write_log(true, true);
 
-    if (pt && parameters_.doRestartPT) {
+    if (pt && domainParameters.doRestartPT) {
       pt->read_restart();
       pt->write_log(true, true);
     }
@@ -686,12 +686,13 @@ void Domain::save_restart_header() {
 
     std::string command_suffix = "_" + gridName + "\n";
 
-    parameters_.doRestart = !fi->is_grid_empty();
+    domainParameters.doRestart = !fi->is_grid_empty();
     headerFile << "#RESTART" + command_suffix;
-    headerFile << (parameters_.doRestart ? "T" : "F") << "\t\t\tdoRestart\n";
+    headerFile << (domainParameters.doRestart ? "T" : "F")
+               << "\t\t\tdoRestart\n";
     headerFile << "\n";
 
-    if (parameters_.receiveICOnly) {
+    if (domainParameters.receiveICOnly) {
       headerFile << "#RESTARTFIONLY" + command_suffix;
       headerFile << "T"
                  << "\t\t\tdoRestartFIOnly\n";
@@ -859,43 +860,39 @@ void Domain::init_time_ctr() {
 
 //========================================================
 void Domain::read_domain_parameters(ReadParam &param) {
-  // Parse only the Domain-level configuration (restart/init/source/PT toggles
-  // and load-balance settings), so that child components can be constructed
-  // gated on the correct values. All other commands are left for the
-  // subsequent read_param(false) pass; because the caller rolls back the
-  // stream afterward, the cursor position reached here does not matter.
+  // Only Domain-level switches are parsed here; the caller rolls back the
+  // stream, so read_param re-reads the whole file afterward.
   std::string command;
   while (param.get_next_command(command)) {
     if (command == "#RESTART") {
-      param.read_var("doRestart", parameters_.doRestart);
-      parameters_.doRestartPT = parameters_.doRestart;
+      param.read_var("doRestart", domainParameters.doRestart);
+      domainParameters.doRestartPT = domainParameters.doRestart;
     } else if (command == "#TPRESTART") {
-      param.read_var("doTPRestart", parameters_.doRestartPT);
+      param.read_var("doTPRestart", domainParameters.doRestartPT);
     } else if (command == "#RESTARTFIONLY") {
-      param.read_var("doRestartFIOnly", parameters_.doRestartFIOnly);
+      param.read_var("doRestartFIOnly", domainParameters.doRestartFIOnly);
     } else if (command == "#INITFROMSWMF") {
-      param.read_var("initFromSWMF", parameters_.initFromSWMF);
+      param.read_var("initFromSWMF", domainParameters.initFromSWMF);
     } else if (command == "#RECEIVEICONLY") {
-      param.read_var("receiveICOnly", parameters_.receiveICOnly);
+      param.read_var("receiveICOnly", domainParameters.receiveICOnly);
     } else if (command == "#NOUTFILE") {
-      param.read_var("nFileField", parameters_.nFileField);
-      param.read_var("nFileParticle", parameters_.nFileParticle);
+      param.read_var("nFileField", domainParameters.nFileField);
+      param.read_var("nFileParticle", domainParameters.nFileParticle);
     } else if (command == "#PARTICLETRACKER") {
-      param.read_var("usePT", parameters_.usePT);
+      param.read_var("usePT", domainParameters.usePT);
     } else if (command == "#SOURCE") {
-      param.read_var("useSource", parameters_.useSource);
+      param.read_var("useSource", domainParameters.useSource);
     } else if (command == "#LOADBALANCE") {
       std::string strategy;
       param.read_var("loadBalanceStrategy", strategy);
       strategy[0] = toupper(strategy[0]);
-      parameters_.balanceStrategy = stringToBalanceStrategy.at(strategy);
+      domainParameters.balanceStrategy = stringToBalanceStrategy.at(strategy);
 
-      if (parameters_.balanceStrategy == BalanceStrategy::Hybrid) {
-        param.read_var("cellWeight", parameters_.cellWeight);
+      if (domainParameters.balanceStrategy == BalanceStrategy::Hybrid) {
+        param.read_var("cellWeight", domainParameters.cellWeight);
       }
     }
-    // Non-Domain commands are skipped: get_next_command advances to the next
-    // command line, ignoring their value lines.
+    // Non-Domain commands are left for read_param's later pass.
   }
 }
 
@@ -981,10 +978,10 @@ void Domain::read_param(const bool readGridInfo) {
       std::string strategy;
       param.read_var("loadBalanceStrategy", strategy);
       strategy[0] = toupper(strategy[0]);
-      parameters_.balanceStrategy = stringToBalanceStrategy.at(strategy);
+      domainParameters.balanceStrategy = stringToBalanceStrategy.at(strategy);
 
-      if (parameters_.balanceStrategy == BalanceStrategy::Hybrid) {
-        param.read_var("cellWeight", parameters_.cellWeight);
+      if (domainParameters.balanceStrategy == BalanceStrategy::Hybrid) {
+        param.read_var("cellWeight", domainParameters.cellWeight);
       }
 
       int dn;
@@ -994,20 +991,20 @@ void Domain::read_param(const bool readGridInfo) {
       tc->loadBalance.init(dt, dn);
 
     } else if (command == "#PARTICLETRACKER") {
-      param.read_var("usePT", parameters_.usePT);
+      param.read_var("usePT", domainParameters.usePT);
     } else if (command == "#SOURCE") {
-      param.read_var("useSource", parameters_.useSource);
+      param.read_var("useSource", domainParameters.useSource);
     } else if (command == "#RESTART") {
-      param.read_var("doRestart", parameters_.doRestart);
-      parameters_.doRestartPT = parameters_.doRestart;
+      param.read_var("doRestart", domainParameters.doRestart);
+      domainParameters.doRestartPT = domainParameters.doRestart;
     } else if (command == "#TPRESTART") {
-      param.read_var("doTPRestart", parameters_.doRestartPT);
+      param.read_var("doTPRestart", domainParameters.doRestartPT);
     } else if (command == "#RESTARTFIONLY") {
-      param.read_var("doRestartFIOnly", parameters_.doRestartFIOnly);
+      param.read_var("doRestartFIOnly", domainParameters.doRestartFIOnly);
     } else if (command == "#INITFROMSWMF") {
-      param.read_var("initFromSWMF", parameters_.initFromSWMF);
+      param.read_var("initFromSWMF", domainParameters.initFromSWMF);
     } else if (command == "#RECEIVEICONLY") {
-      param.read_var("receiveICOnly", parameters_.receiveICOnly);
+      param.read_var("receiveICOnly", domainParameters.receiveICOnly);
     } else if (command == "#GEOMETRY") {
       for (int i = 0; i < nDim; ++i) {
         Real lo, hi;
@@ -1115,8 +1112,8 @@ void Domain::read_param(const bool readGridInfo) {
         amrInfo.ref_ratio.push_back(IntVect(rr));
       }
     } else if (command == "#NOUTFILE") {
-      param.read_var("nFileField", parameters_.nFileField);
-      param.read_var("nFileParticle", parameters_.nFileParticle);
+      param.read_var("nFileField", domainParameters.nFileField);
+      param.read_var("nFileParticle", domainParameters.nFileParticle);
     } else if (command == "#MAXBLOCKSIZE") {
       // The block size in each direction can not larger than maxBlockSize.
       int tmp;
@@ -1287,7 +1284,7 @@ void Domain::read_param(const bool readGridInfo) {
       pic->post_process_param();
 
     if (fi)
-      fi->post_process_param(parameters_);
+      fi->post_process_param(domainParameters);
 
     // Final sync of source's FluidInterfaceParameters from fi, now that
     // fi->post_process_param() has finalized the derived arrays (MoMi_S,
@@ -1308,10 +1305,10 @@ void Domain::read_param(const bool readGridInfo) {
     }
   }
 
-  VisMF::SetNOutFiles(parameters_.nFileField);
+  VisMF::SetNOutFiles(domainParameters.nFileField);
 
   ParmParse pp("particles");
-  pp.add("particles_nfiles", parameters_.nFileParticle);
+  pp.add("particles_nfiles", domainParameters.nFileParticle);
 }
 
 //========================================================

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -18,15 +18,15 @@ void Domain::init(double time, const int iDomain,
   printPrefix = gridName + ": ";
 
 #ifdef _PT_COMPONENT_
-  useSource = true;
+  parameters_.useSource = true;
 #endif
 
   { // It looks like the file saving may crash if the size of a single file is
     // too large. The numbers 64 and 2048 are chosen empirically.
     const int nFileBase = 64;
     int np = floor(ParallelDescriptor::NProcs() / 2048.0) + 1;
-    nFileField = np * nFileBase;
-    nFileParticle = np * nFileBase * 4;
+    parameters_.nFileField = np * nFileBase;
+    parameters_.nFileParticle = np * nFileBase * 4;
   }
 
   param = paramString;
@@ -40,7 +40,7 @@ void Domain::init(double time, const int iDomain,
   refineRegionsStr.resize(amrInfo.max_level + 1);
   refineRegions.resize(amrInfo.max_level + 1);
 
-  if (receiveICOnly) {
+  if (parameters_.receiveICOnly) {
     fi = std::make_unique<FluidInterface>(gm, amrInfo, nGst, gridID, "fi");
     ptInfo.set_fluid_interface(fi.get());
     read_param(false);
@@ -50,7 +50,7 @@ void Domain::init(double time, const int iDomain,
     return;
   }
 
-  if (initFromSWMF && !receiveICOnly) {
+  if (parameters_.initFromSWMF && !parameters_.receiveICOnly) {
     fi = std::make_unique<FluidInterface>(
         gm, amrInfo, nGst, gridID, "fi", paramInt,
         Vector<double>(paramRegion.begin() + 18, paramRegion.end()), paramComm);
@@ -62,7 +62,7 @@ void Domain::init(double time, const int iDomain,
   ptInfo.set_fluid_interface(fi.get());
   pic = std::make_unique<Pic>(gm, amrInfo, nGst, fi.get(), tc.get(), gridID);
 
-  if (usePT)
+  if (parameters_.usePT)
     pt = std::make_unique<ParticleTracker>(gm, amrInfo, nGst, fi.get(),
                                            tc.get(), gridID, ptInfo);
 
@@ -90,7 +90,7 @@ void Domain::init(double time, const int iDomain,
 
   // #SOURCE command sets useSource during read_param; discard the
   // source object if user did not request a source.
-  if (!useSource) {
+  if (!parameters_.useSource) {
     source.reset();
   } else {
     amrex::Print() << source->get_info() << " is used for source" << std::endl;
@@ -113,7 +113,7 @@ void Domain::init(double time, const int iDomain,
 
   pic->init_source(*fi);
 
-  if (doRestart) {
+  if (parameters_.doRestart) {
     // Restoring the restart data before coupling with GM, because the PIC grid
     // may change again during coupling.
     read_restart();
@@ -220,7 +220,7 @@ void Domain::update() {
   // - GM-PC: called from set_state_var() at coupling intervals; fi is
   //   unchanged between couplings, so skip here.
   // - OH-PT: not applicable; charge_exchange() handles source terms.
-  if (source && !initFromSWMF) {
+  if (source && !parameters_.initFromSWMF) {
     source->set_source(*fi);
     source->sum_boundary();
     source->sum_loss_boundary();
@@ -257,7 +257,7 @@ void Domain::prepare_grid_info(const Vector<double> &info) {
   if (isFake2D)
     set_periodicity(iz_, true);
 
-  bool setGridFromSWMF = !doRestart && initFromSWMF && !receiveICOnly;
+  bool setGridFromSWMF = !parameters_.doRestart && parameters_.initFromSWMF && !parameters_.receiveICOnly;
 
   if (setGridFromSWMF) {
     // If restart, the grid info will be read from restart.H
@@ -323,7 +323,7 @@ void Domain::prepare_grid_info(const Vector<double> &info) {
 void Domain::load_balance() {
   timing_func("Domain::load_balance");
 
-  pic->calc_cost_per_cell(balanceStrategy, cellWeight);
+  pic->calc_cost_per_cell(parameters_);
 
   fi->set_cost(pic->get_cost());
 
@@ -435,12 +435,12 @@ void Domain::receive_grid_info(int *status) { gridInfo.set_status(status); }
 //========================================================
 void Domain::set_ic() {
 
-  if (receiveICOnly)
+  if (parameters_.receiveICOnly)
     return;
 
   // If it is restart, the values should have been restored before coupling
   // with GM. See Domain::init().
-  if (!(doRestart && !doRestartFIOnly)) {
+  if (!(parameters_.doRestart && !parameters_.doRestartFIOnly)) {
 
     fi->set_node_fluid();
 
@@ -450,7 +450,7 @@ void Domain::set_ic() {
     pic->write_log(true, true);
   }
 
-  if (!doRestartPT) {
+  if (!parameters_.doRestartPT) {
     if (pt)
       pt->set_ic(*pic);
 
@@ -473,7 +473,7 @@ void Domain::set_state_var(double *data, int *index,
   Print() << printPrefix << " " << sourceComp << " -> " << component
           << " coupling at t =" << tc->get_time_si() << " (s)" << std::endl;
 
-  if (receiveICOnly) {
+  if (parameters_.receiveICOnly) {
     fi->set_node_fluid(data, index, names);
     // For some cases, the variables information is not unknown until the first
     // couping is called.
@@ -598,7 +598,7 @@ void Domain::read_restart() {
   fi->regrid(grid.boxArray(0), &grid);
   fi->read_restart();
 
-  if (!doRestartFIOnly) {
+  if (!parameters_.doRestartFIOnly) {
     pic->regrid(grid.boxArray(0), fi.get());
 
     if (pt)
@@ -608,7 +608,7 @@ void Domain::read_restart() {
     write_plots(true);
     pic->write_log(true, true);
 
-    if (pt && doRestartPT) {
+    if (pt && parameters_.doRestartPT) {
       pt->read_restart();
       pt->write_log(true, true);
     }
@@ -675,12 +675,12 @@ void Domain::save_restart_header() {
 
     std::string command_suffix = "_" + gridName + "\n";
 
-    doRestart = !fi->is_grid_empty();
+    parameters_.doRestart = !fi->is_grid_empty();
     headerFile << "#RESTART" + command_suffix;
-    headerFile << (doRestart ? "T" : "F") << "\t\t\tdoRestart\n";
+    headerFile << (parameters_.doRestart ? "T" : "F") << "\t\t\tdoRestart\n";
     headerFile << "\n";
 
-    if (receiveICOnly) {
+    if (parameters_.receiveICOnly) {
       headerFile << "#RESTARTFIONLY" + command_suffix;
       headerFile << "T"
                  << "\t\t\tdoRestartFIOnly\n";
@@ -928,10 +928,10 @@ void Domain::read_param(const bool readGridInfo) {
       std::string strategy;
       param.read_var("loadBalanceStrategy", strategy);
       strategy[0] = toupper(strategy[0]);
-      balanceStrategy = stringToBalanceStrategy.at(strategy);
+      parameters_.balanceStrategy = stringToBalanceStrategy.at(strategy);
 
-      if (balanceStrategy == BalanceStrategy::Hybrid) {
-        param.read_var("cellWeight", cellWeight);
+      if (parameters_.balanceStrategy == BalanceStrategy::Hybrid) {
+        param.read_var("cellWeight", parameters_.cellWeight);
       }
 
       int dn;
@@ -941,20 +941,20 @@ void Domain::read_param(const bool readGridInfo) {
       tc->loadBalance.init(dt, dn);
 
     } else if (command == "#PARTICLETRACKER") {
-      param.read_var("usePT", usePT);
+      param.read_var("usePT", parameters_.usePT);
     } else if (command == "#SOURCE") {
-      param.read_var("useSource", useSource);
+      param.read_var("useSource", parameters_.useSource);
     } else if (command == "#RESTART") {
-      param.read_var("doRestart", doRestart);
-      doRestartPT = doRestart;
+      param.read_var("doRestart", parameters_.doRestart);
+      parameters_.doRestartPT = parameters_.doRestart;
     } else if (command == "#TPRESTART") {
-      param.read_var("doTPRestart", doRestartPT);
+      param.read_var("doTPRestart", parameters_.doRestartPT);
     } else if (command == "#RESTARTFIONLY") {
-      param.read_var("doRestartFIOnly", doRestartFIOnly);
+      param.read_var("doRestartFIOnly", parameters_.doRestartFIOnly);
     } else if (command == "#INITFROMSWMF") {
-      param.read_var("initFromSWMF", initFromSWMF);
+      param.read_var("initFromSWMF", parameters_.initFromSWMF);
     } else if (command == "#RECEIVEICONLY") {
-      param.read_var("receiveICOnly", receiveICOnly);
+      param.read_var("receiveICOnly", parameters_.receiveICOnly);
     } else if (command == "#GEOMETRY") {
       for (int i = 0; i < nDim; ++i) {
         Real lo, hi;
@@ -1062,8 +1062,8 @@ void Domain::read_param(const bool readGridInfo) {
         amrInfo.ref_ratio.push_back(IntVect(rr));
       }
     } else if (command == "#NOUTFILE") {
-      param.read_var("nFileField", nFileField);
-      param.read_var("nFileParticle", nFileParticle);
+      param.read_var("nFileField", parameters_.nFileField);
+      param.read_var("nFileParticle", parameters_.nFileParticle);
     } else if (command == "#MAXBLOCKSIZE") {
       // The block size in each direction can not larger than maxBlockSize.
       int tmp;
@@ -1234,7 +1234,7 @@ void Domain::read_param(const bool readGridInfo) {
       pic->post_process_param();
 
     if (fi)
-      fi->post_process_param(receiveICOnly);
+      fi->post_process_param(parameters_);
 
     // Final sync of source's FluidInterfaceParameters from fi, now that
     // fi->post_process_param() has finalized the derived arrays (MoMi_S,
@@ -1255,10 +1255,10 @@ void Domain::read_param(const bool readGridInfo) {
     }
   }
 
-  VisMF::SetNOutFiles(nFileField);
+  VisMF::SetNOutFiles(parameters_.nFileField);
 
   ParmParse pp("particles");
-  pp.add("particles_nfiles", nFileParticle);
+  pp.add("particles_nfiles", parameters_.nFileParticle);
 }
 
 //========================================================

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -37,6 +37,14 @@ void Domain::init(double time, const int iDomain,
 
   prepare_grid_info(paramRegion);
 
+  // Pre-pass: finalize Domain-level configuration BEFORE constructing child
+  // components, so construction can be gated on the correct values
+  // (usePT gates the ParticleTracker; useSource/usePT gate the source).
+  {
+    read_domain_parameters(param);
+    param.roll_back();
+  }
+
   refineRegionsStr.resize(amrInfo.max_level + 1);
   refineRegions.resize(amrInfo.max_level + 1);
 
@@ -60,16 +68,19 @@ void Domain::init(double time, const int iDomain,
   }
 
   ptInfo.set_fluid_interface(fi.get());
-  pic = std::make_unique<Pic>(gm, amrInfo, nGst, fi.get(), tc.get(), gridID);
+  pic = std::make_unique<Pic>(gm, amrInfo, nGst, fi.get(), tc.get(),
+                                 gridID, parameters_);
 
   if (parameters_.usePT)
     pt = std::make_unique<ParticleTracker>(gm, amrInfo, nGst, fi.get(),
-                                           tc.get(), gridID, ptInfo);
+                                           tc.get(), gridID, ptInfo,
+                                           parameters_);
 
   // Create the source object before read_param so that ionization
   // commands (#PHOTOIONIZATION, #ELECTRONIMPACT, #CHARGEEXCHANGE)
   // can be dispatched to source->read_param().
-  source = std::make_unique<UserSource>(*fi, gridID, "picSource", SourceFluid);
+  source = std::make_unique<UserSource>(*fi, gridID, "picSource", SourceFluid,
+                                       parameters_);
 
   read_param(false);
 
@@ -323,7 +334,7 @@ void Domain::prepare_grid_info(const Vector<double> &info) {
 void Domain::load_balance() {
   timing_func("Domain::load_balance");
 
-  pic->calc_cost_per_cell(parameters_);
+  pic->calc_cost_per_cell();
 
   fi->set_cost(pic->get_cost());
 
@@ -844,6 +855,48 @@ void Domain::init_time_ctr() {
   }
 
   isTCInitialized = true;
+}
+
+//========================================================
+void Domain::read_domain_parameters(ReadParam &param) {
+  // Parse only the Domain-level configuration (restart/init/source/PT toggles
+  // and load-balance settings), so that child components can be constructed
+  // gated on the correct values. All other commands are left for the
+  // subsequent read_param(false) pass; because the caller rolls back the
+  // stream afterward, the cursor position reached here does not matter.
+  std::string command;
+  while (param.get_next_command(command)) {
+    if (command == "#RESTART") {
+      param.read_var("doRestart", parameters_.doRestart);
+      parameters_.doRestartPT = parameters_.doRestart;
+    } else if (command == "#TPRESTART") {
+      param.read_var("doTPRestart", parameters_.doRestartPT);
+    } else if (command == "#RESTARTFIONLY") {
+      param.read_var("doRestartFIOnly", parameters_.doRestartFIOnly);
+    } else if (command == "#INITFROMSWMF") {
+      param.read_var("initFromSWMF", parameters_.initFromSWMF);
+    } else if (command == "#RECEIVEICONLY") {
+      param.read_var("receiveICOnly", parameters_.receiveICOnly);
+    } else if (command == "#NOUTFILE") {
+      param.read_var("nFileField", parameters_.nFileField);
+      param.read_var("nFileParticle", parameters_.nFileParticle);
+    } else if (command == "#PARTICLETRACKER") {
+      param.read_var("usePT", parameters_.usePT);
+    } else if (command == "#SOURCE") {
+      param.read_var("useSource", parameters_.useSource);
+    } else if (command == "#LOADBALANCE") {
+      std::string strategy;
+      param.read_var("loadBalanceStrategy", strategy);
+      strategy[0] = toupper(strategy[0]);
+      parameters_.balanceStrategy = stringToBalanceStrategy.at(strategy);
+
+      if (parameters_.balanceStrategy == BalanceStrategy::Hybrid) {
+        param.read_var("cellWeight", parameters_.cellWeight);
+      }
+    }
+    // Non-Domain commands are skipped: get_next_command advances to the next
+    // command line, ignoring their value lines.
+  }
 }
 
 //========================================================

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -29,7 +29,7 @@ void Domain::init(double time, const int iDomain,
     domainParameters.nFileParticle = np * nFileBase * 4;
   }
 
-  param = paramString;
+  readParam = paramString;
 
   if (!paramInt.empty())
     if (paramInt[0] == 2 && nDim == 3)
@@ -39,8 +39,8 @@ void Domain::init(double time, const int iDomain,
 
   // Read Domain-level switches, then rewind so read_param re-reads the file.
   {
-    read_domain_parameters(param);
-    param.roll_back();
+    read_domain_parameters(readParam);
+    readParam.roll_back();
   }
 
   refineRegionsStr.resize(amrInfo.max_level + 1);
@@ -251,7 +251,7 @@ void Domain::update() {
 
 //========================================================
 void Domain::update_param(const std::string &paramString) {
-  param = paramString;
+  readParam = paramString;
   read_param(false);
   init_time_ctr();
 };
@@ -260,7 +260,7 @@ void Domain::update_param(const std::string &paramString) {
 void Domain::prepare_grid_info(const Vector<double> &info) {
 
   read_param(true);
-  param.roll_back();
+  readParam.roll_back();
 
   // If MHD is 2D, PIC has to be periodic in the z-direction.
   if (isFake2D)
@@ -859,37 +859,37 @@ void Domain::init_time_ctr() {
 }
 
 //========================================================
-void Domain::read_domain_parameters(ReadParam &param) {
+void Domain::read_domain_parameters(ReadParam &rp) {
   // Only Domain-level switches are parsed here; the caller rolls back the
   // stream, so read_param re-reads the whole file afterward.
   std::string command;
-  while (param.get_next_command(command)) {
+  while (rp.get_next_command(command)) {
     if (command == "#RESTART") {
-      param.read_var("doRestart", domainParameters.doRestart);
+      rp.read_var("doRestart", domainParameters.doRestart);
       domainParameters.doRestartPT = domainParameters.doRestart;
     } else if (command == "#TPRESTART") {
-      param.read_var("doTPRestart", domainParameters.doRestartPT);
+      rp.read_var("doTPRestart", domainParameters.doRestartPT);
     } else if (command == "#RESTARTFIONLY") {
-      param.read_var("doRestartFIOnly", domainParameters.doRestartFIOnly);
+      rp.read_var("doRestartFIOnly", domainParameters.doRestartFIOnly);
     } else if (command == "#INITFROMSWMF") {
-      param.read_var("initFromSWMF", domainParameters.initFromSWMF);
+      rp.read_var("initFromSWMF", domainParameters.initFromSWMF);
     } else if (command == "#RECEIVEICONLY") {
-      param.read_var("receiveICOnly", domainParameters.receiveICOnly);
+      rp.read_var("receiveICOnly", domainParameters.receiveICOnly);
     } else if (command == "#NOUTFILE") {
-      param.read_var("nFileField", domainParameters.nFileField);
-      param.read_var("nFileParticle", domainParameters.nFileParticle);
+      rp.read_var("nFileField", domainParameters.nFileField);
+      rp.read_var("nFileParticle", domainParameters.nFileParticle);
     } else if (command == "#PARTICLETRACKER") {
-      param.read_var("usePT", domainParameters.usePT);
+      rp.read_var("usePT", domainParameters.usePT);
     } else if (command == "#SOURCE") {
-      param.read_var("useSource", domainParameters.useSource);
+      rp.read_var("useSource", domainParameters.useSource);
     } else if (command == "#LOADBALANCE") {
       std::string strategy;
-      param.read_var("loadBalanceStrategy", strategy);
+      rp.read_var("loadBalanceStrategy", strategy);
       strategy[0] = toupper(strategy[0]);
       domainParameters.balanceStrategy = stringToBalanceStrategy.at(strategy);
 
       if (domainParameters.balanceStrategy == BalanceStrategy::Hybrid) {
-        param.read_var("cellWeight", domainParameters.cellWeight);
+        rp.read_var("cellWeight", domainParameters.cellWeight);
       }
     }
     // Non-Domain commands are left for read_param's later pass.
@@ -902,11 +902,11 @@ void Domain::read_param(const bool readGridInfo) {
 
   std::string command;
 
-  param.set_verbose(false);
+  readParam.set_verbose(false);
   bool sourceParamsSynced = false;
-  param.set_command_suffix(gridName);
-  param.set_component(component);
-  while (param.get_next_command(command)) {
+  readParam.set_command_suffix(gridName);
+  readParam.set_component(component);
+  while (readParam.get_next_command(command)) {
 
     bool isGridCommand =
         command == "#MAXBLOCKSIZE" || command == "#PERIODICITY" ||
@@ -925,7 +925,7 @@ void Domain::read_param(const bool readGridInfo) {
       continue;
     }
 
-    param.set_verbose(ParallelDescriptor::IOProcessor());
+    readParam.set_verbose(ParallelDescriptor::IOProcessor());
     Print() << "\n"
             << component << ": " << command << " " << gridName << std::endl;
 
@@ -949,12 +949,12 @@ void Domain::read_param(const bool readGridInfo) {
         command == "#SELECTPARTICLE" || command == "#MAXCHARGEEXCHANGERATE" ||
         command == "#MEMORY") {
       if (pic)
-        pic->read_param(command, param);
+        pic->read_param(command, readParam);
     } else if (command == "#TESTPARTICLENUMBER" || command == "#TPPARTICLES" ||
                command == "#TPCELLINTERVAL" || command == "#TPREGION" ||
                command == "#TPSAVE" || command == "#TPRELATIVISTIC" ||
                command == "#TPINITFROMPIC" || command == "#TPSTATESI") {
-      ptInfo.read_param(command, param);
+      ptInfo.read_param(command, readParam);
     } else if (command == "#PHOTOIONIZATION" || command == "#ELECTRONIMPACT" ||
                command == "#CHARGEEXCHANGE" || command == "#SHADOWCYLINDER" ||
                command == "#RECOMBINATION" || command == "#CHEMISTRY") {
@@ -967,49 +967,49 @@ void Domain::read_param(const bool readGridInfo) {
           source->sync_fluid_interface_params(*fi);
           sourceParamsSynced = true;
         }
-        source->read_param(command, param);
+        source->read_param(command, readParam);
       }
     } else if (command == "#NORMALIZATION" || command == "#SCALINGFACTOR" ||
                command == "#BODYSIZE" || command == "#EXOSPHERE" ||
                command == "#PLASMA" || command == "#UNIFORMSTATE" ||
                command == "#FLUIDVARNAMES" || command == "#WAVE") {
-      fi->read_param(command, param);
+      fi->read_param(command, readParam);
     } else if (command == "#LOADBALANCE") {
       std::string strategy;
-      param.read_var("loadBalanceStrategy", strategy);
+      readParam.read_var("loadBalanceStrategy", strategy);
       strategy[0] = toupper(strategy[0]);
       domainParameters.balanceStrategy = stringToBalanceStrategy.at(strategy);
 
       if (domainParameters.balanceStrategy == BalanceStrategy::Hybrid) {
-        param.read_var("cellWeight", domainParameters.cellWeight);
+        readParam.read_var("cellWeight", domainParameters.cellWeight);
       }
 
       int dn;
-      param.read_var("dn", dn);
+      readParam.read_var("dn", dn);
       Real dt;
-      param.read_var("dt", dt);
+      readParam.read_var("dt", dt);
       tc->loadBalance.init(dt, dn);
 
     } else if (command == "#PARTICLETRACKER") {
-      param.read_var("usePT", domainParameters.usePT);
+      readParam.read_var("usePT", domainParameters.usePT);
     } else if (command == "#SOURCE") {
-      param.read_var("useSource", domainParameters.useSource);
+      readParam.read_var("useSource", domainParameters.useSource);
     } else if (command == "#RESTART") {
-      param.read_var("doRestart", domainParameters.doRestart);
+      readParam.read_var("doRestart", domainParameters.doRestart);
       domainParameters.doRestartPT = domainParameters.doRestart;
     } else if (command == "#TPRESTART") {
-      param.read_var("doTPRestart", domainParameters.doRestartPT);
+      readParam.read_var("doTPRestart", domainParameters.doRestartPT);
     } else if (command == "#RESTARTFIONLY") {
-      param.read_var("doRestartFIOnly", domainParameters.doRestartFIOnly);
+      readParam.read_var("doRestartFIOnly", domainParameters.doRestartFIOnly);
     } else if (command == "#INITFROMSWMF") {
-      param.read_var("initFromSWMF", domainParameters.initFromSWMF);
+      readParam.read_var("initFromSWMF", domainParameters.initFromSWMF);
     } else if (command == "#RECEIVEICONLY") {
-      param.read_var("receiveICOnly", domainParameters.receiveICOnly);
+      readParam.read_var("receiveICOnly", domainParameters.receiveICOnly);
     } else if (command == "#GEOMETRY") {
       for (int i = 0; i < nDim; ++i) {
         Real lo, hi;
-        param.read_var("min", lo);
-        param.read_var("max", hi);
+        readParam.read_var("min", lo);
+        readParam.read_var("max", hi);
         domainRange.setLo(i, lo);
         domainRange.setHi(i, hi);
       }
@@ -1017,24 +1017,24 @@ void Domain::read_param(const bool readGridInfo) {
         Abort("Error: invalid input!");
     } else if (command == "#NCELL") {
       for (int i = 0; i < nDim; ++i) {
-        param.read_var("nCell", nCell[i]);
+        readParam.read_var("nCell", nCell[i]);
         if (nCell[i] <= 0)
           Abort("Error: invalid input!");
       }
       isFake2D = (nDim == 3) && (nCell[iz_] == 1);
 
     } else if (command == "#GRIDEFFICIENCY") {
-      param.read_var("gridEfficiency", gridEfficiency);
+      readParam.read_var("gridEfficiency", gridEfficiency);
     } else if (command == "#REGION") {
       std::string name, type;
-      param.read_var("name", name);
-      param.read_var("shape", type);
+      readParam.read_var("name", name);
+      readParam.read_var("shape", type);
 
       if (type == "box") {
         Real lo[nDim], hi[nDim];
         for (int i = 0; i < nDim; ++i) {
-          param.read_var("min", lo[i]);
-          param.read_var("max", hi[i]);
+          readParam.read_var("min", lo[i]);
+          readParam.read_var("max", hi[i]);
         }
 
         if (SpaceDim > 2 && isFake2D) {
@@ -1047,9 +1047,9 @@ void Domain::read_param(const bool readGridInfo) {
 
         Real center[nDim], radius;
         for (int i = 0; i < nDim; ++i) {
-          param.read_var("center", center[i]);
+          readParam.read_var("center", center[i]);
         }
-        param.read_var("radius", radius);
+        readParam.read_var("radius", radius);
 
         if (SpaceDim > 2 && isFake2D) {
           center[iz_] = 0;
@@ -1061,10 +1061,10 @@ void Domain::read_param(const bool readGridInfo) {
 
         Real center[nDim], rInner, rOuter;
         for (int i = 0; i < nDim; ++i) {
-          param.read_var("center", center[i]);
+          readParam.read_var("center", center[i]);
         }
-        param.read_var("rInner", rInner);
-        param.read_var("rOuter", rOuter);
+        readParam.read_var("rInner", rInner);
+        readParam.read_var("rOuter", rOuter);
 
         if (SpaceDim > 2 && isFake2D) {
           center[iz_] = 0;
@@ -1075,14 +1075,14 @@ void Domain::read_param(const bool readGridInfo) {
         int iAxis;
         Real center[nDim], height, r1, r2;
 
-        param.read_var("iAxis", iAxis);
+        readParam.read_var("iAxis", iAxis);
         for (int i = 0; i < nDim; ++i) {
-          param.read_var("center", center[i]);
+          readParam.read_var("center", center[i]);
         }
 
-        param.read_var("height", height);
-        param.read_var("r1", r1);
-        param.read_var("r2", r2);
+        readParam.read_var("height", height);
+        readParam.read_var("r1", r1);
+        readParam.read_var("r2", r2);
 
         if (SpaceDim > 2 && isFake2D) {
           center[iz_] = 0;
@@ -1095,62 +1095,62 @@ void Domain::read_param(const bool readGridInfo) {
     } else if (command == "#REFINEREGION") {
       int iLev;
       std::string s;
-      param.read_var("iLev", iLev);
+      readParam.read_var("iLev", iLev);
 
       if (iLev >= refineRegionsStr.size() - 1)
         Abort("Error: iLev should be smaller than the max level index!");
 
-      param.read_var("regions", s);
+      readParam.read_var("regions", s);
       refineRegionsStr[iLev] = s + " ";
 
     } else if (command == "#REFINEMENTRATIO") {
       int rr;
-      param.read_var("refineRatio", rr);
+      readParam.read_var("refineRatio", rr);
       int size = amrInfo.ref_ratio.size();
       amrInfo.ref_ratio.clear();
       for (int i = 0; i < size; ++i) {
         amrInfo.ref_ratio.push_back(IntVect(rr));
       }
     } else if (command == "#NOUTFILE") {
-      param.read_var("nFileField", domainParameters.nFileField);
-      param.read_var("nFileParticle", domainParameters.nFileParticle);
+      readParam.read_var("nFileField", domainParameters.nFileField);
+      readParam.read_var("nFileParticle", domainParameters.nFileParticle);
     } else if (command == "#MAXBLOCKSIZE") {
       // The block size in each direction can not larger than maxBlockSize.
       int tmp;
       for (int i = 0; i < nDim; ++i) {
-        param.read_var("maxBlockSize", tmp);
+        readParam.read_var("maxBlockSize", tmp);
         maxBlockSize[i] = tmp;
       }
     } else if (command == "#TIMESTEP" || command == "#TIMESTEPPING") {
       bool useFixedDt;
-      param.read_var("useFixedDt", useFixedDt);
+      readParam.read_var("useFixedDt", useFixedDt);
       if (useFixedDt) {
         Real dtSI;
-        param.read_var("dtSI", dtSI);
+        readParam.read_var("dtSI", dtSI);
         tc->set_dt_si(dtSI);
         tc->set_next_dt_si(dtSI);
         tc->set_cfl(-1);
         tc->set_dt_max(dtSI);
       } else {
         Real cfl;
-        param.read_var("cfl", cfl);
+        readParam.read_var("cfl", cfl);
         tc->set_cfl(cfl);
       }
     } else if (command == "#PERIODICITY") {
       for (int i = 0; i < nDim; ++i) {
         bool isPeriodic;
-        param.read_var("isPeriodic", isPeriodic);
+        readParam.read_var("isPeriodic", isPeriodic);
         set_periodicity(i, isPeriodic);
       }
     } else if (command == "#SAVELOG") {
       int dn;
-      param.read_var("dnSavePic", dn);
+      readParam.read_var("dnSavePic", dn);
       tc->picLog.init(-1, dn);
-      param.read_var("dnSavePT", dn);
+      readParam.read_var("dnSavePT", dn);
       tc->ptLog.init(-1, dn);
     } else if (command == "#MONITOR") {
       int dn;
-      param.read_var("dnReport", dn);
+      readParam.read_var("dnReport", dn);
       tc->monitor.init(-1, dn);
     } else if (command == "#SAVEPLOT" || command == "#SAVEIDL") {
 
@@ -1193,7 +1193,7 @@ void Domain::read_param(const bool readGridInfo) {
       */
 
       int nPlot;
-      param.read_var("nPlotFile", nPlot);
+      readParam.read_var("nPlotFile", nPlot);
 
       if (nPlot > 0) {
         tc->plots.clear();
@@ -1202,7 +1202,7 @@ void Domain::read_param(const bool readGridInfo) {
       for (int iPlot = 0; iPlot < nPlot; iPlot++) {
 
         std::string plotString;
-        param.read_var("plotString", plotString);
+        readParam.read_var("plotString", plotString);
         {
           std::string::size_type pos = plotString.find_first_not_of(' ');
           if (pos != std::string::npos)
@@ -1210,27 +1210,27 @@ void Domain::read_param(const bool readGridInfo) {
         }
 
         int dnSave;
-        param.read_var("dnSavePlot", dnSave);
+        readParam.read_var("dnSavePlot", dnSave);
 
         Real dtSave;
-        param.read_var("dtSavePlot", dtSave);
+        readParam.read_var("dtSavePlot", dtSave);
 
         RealVect plotMin_D = { AMREX_D_DECL(1, 1, 1) },
                  plotMax_D = { AMREX_D_DECL(-1, -1, -1) };
         if (plotString.find("cut") != std::string::npos) {
           // Output range is 'cut' type.
           for (int iDim = 0; iDim < nDim; iDim++) {
-            param.read_var("plotMin", plotMin_D[iDim]);
-            param.read_var("plotMax", plotMax_D[iDim]);
+            readParam.read_var("plotMin", plotMin_D[iDim]);
+            readParam.read_var("plotMax", plotMax_D[iDim]);
           }
         }
 
         int dxSave;
-        param.read_var("dxSavePlot", dxSave);
+        readParam.read_var("dxSavePlot", dxSave);
 
         std::string plotVar;
         if (plotString.find("var") != std::string::npos) {
-          param.read_var("plotVar", plotVar);
+          readParam.read_var("plotVar", plotVar);
         }
 
         PlotCtr pcTmp(ParallelDescriptor::Communicator(), tc.get(), iPlot,
@@ -1241,25 +1241,25 @@ void Domain::read_param(const bool readGridInfo) {
     } else if (command == "#OHMSLAW") {
       std::string sOhmU;
       Real eta;
-      param.read_var("OhmU", sOhmU);
-      param.read_var("resistivity", eta);
+      readParam.read_var("OhmU", sOhmU);
+      readParam.read_var("resistivity", eta);
 
       fi->set_resistivity(eta);
       fi->set_ohm_u(sOhmU);
       //--------- The commands below exist in restart.H only --------
     } else if (command == "#NSTEP") {
       int nStep;
-      param.read_var("nStep", nStep);
+      readParam.read_var("nStep", nStep);
       tc->set_cycle(nStep);
     } else if (command == "#TIMESIMULATION") {
       Real time;
-      param.read_var("time", time);
+      readParam.read_var("time", time);
       tc->set_time_si(time);
     } else if (command == "#DT") {
       // NOTE: this command is useful only for CFL based time stepping.
       Real dtSI, dtNextSI;
-      param.read_var("dtSI", dtSI);
-      param.read_var("dtNextSI", dtNextSI);
+      readParam.read_var("dtSI", dtSI);
+      readParam.read_var("dtNextSI", dtNextSI);
       tc->set_dt_si(dtSI);
       tc->set_next_dt_si(dtNextSI);
     } else {
@@ -1267,7 +1267,7 @@ void Domain::read_param(const bool readGridInfo) {
       Abort("Can not find this command!");
     }
     //--------- The commands above exist in restart.H only --------
-    param.set_verbose(false);
+    readParam.set_verbose(false);
   } // While
 
   // Post processing

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -887,6 +887,22 @@ void FluidInterface::calc_conversion_units() {
 
 //-------------------------------------------------------------------------
 
+void FluidInterface::sync_normalization_params(const FluidInterface& other) {
+  // Copy only the normalization base parameters (those that
+  // calc_normalization_units() reads and that fi->post_process_param()
+  // finalizes) and recompute the derived normalization units.  Deliberately
+  // leave nS / MoMi_S / QoQi_S / varNames / iRho_I untouched: secondary
+  // interfaces (OHInterface) manage those themselves (constructor resets
+  // and set_node_fluid -> analyze_var_names).
+  lNormSI = other.lNormSI;
+  uNormSI = other.uNormSI;
+  mNormSI = other.mNormSI;
+  rPlanetSi = other.rPlanetSi;
+  calc_normalization_units();
+}
+
+//-------------------------------------------------------------------------
+
 void FluidInterface::calc_normalization_units() {
 
   // Normalization units converted [SI] -> [cgs]

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -104,7 +104,8 @@ void FluidInterface::post_process_param(bool receiveICOnly) {
   const Real protonMassPerChargeSI = cProtonMassSI / cUnitChargeSI;
 
   normParams->mNormSI =
-      1e7 * normParams->lNormSI * pow(protonMassPerChargeSI * normParams->ScalingFactor, 2);
+      1e7 * normParams->lNormSI *
+      pow(protonMassPerChargeSI * normParams->ScalingFactor, 2);
 
   // rPlanetSi default set in #NORMALIZATION read_param; only override
   // if it was not already set by #BODYSIZE.
@@ -804,9 +805,12 @@ void FluidInterface::convert_moment_to_velocity(bool phyNodeOnly, bool doWarn) {
             } else {
               const Real* dx = Geom(iLev).CellSize();
               const auto plo = Geom(iLev).ProbLo();
-              const Real x = (i * dx[ix_] + plo[ix_]) * normParams->No2SiL / normParams->rPlanetSi;
-              const Real y = (j * dx[iy_] + plo[iy_]) * normParams->No2SiL / normParams->rPlanetSi;
-              const Real z = (k * dx[iz_] + plo[iz_]) * normParams->No2SiL / normParams->rPlanetSi;
+              const Real x = (i * dx[ix_] + plo[ix_]) * normParams->No2SiL /
+                             normParams->rPlanetSi;
+              const Real y = (j * dx[iy_] + plo[iy_]) * normParams->No2SiL /
+                             normParams->rPlanetSi;
+              const Real z = (k * dx[iz_] + plo[iz_]) * normParams->No2SiL /
+                             normParams->rPlanetSi;
               if (doWarn) {
                 printf("Warning: ZERO density at x = %e, y = %e, z = %e\n", x,
                        y, z);
@@ -1066,13 +1070,20 @@ void FluidInterface::print_info() const {
     std::cout << printPrefix
               << "========== Unit conversion factors =============="
               << std::endl;
-    std::cout << printPrefix << "Si2NoRho = " << normParams->Si2NoRho << std::endl;
-    std::cout << printPrefix << "Si2NoV   = " << normParams->Si2NoV << std::endl;
-    std::cout << printPrefix << "Si2NoB   = " << normParams->Si2NoB << std::endl;
-    std::cout << printPrefix << "Si2NoE   = " << normParams->Si2NoE << std::endl;
-    std::cout << printPrefix << "Si2NoP   = " << normParams->Si2NoP << std::endl;
-    std::cout << printPrefix << "Si2NoJ   = " << normParams->Si2NoJ << std::endl;
-    std::cout << printPrefix << "Si2NoL   = " << normParams->Si2NoL << std::endl;
+    std::cout << printPrefix << "Si2NoRho = " << normParams->Si2NoRho
+              << std::endl;
+    std::cout << printPrefix << "Si2NoV   = " << normParams->Si2NoV
+              << std::endl;
+    std::cout << printPrefix << "Si2NoB   = " << normParams->Si2NoB
+              << std::endl;
+    std::cout << printPrefix << "Si2NoE   = " << normParams->Si2NoE
+              << std::endl;
+    std::cout << printPrefix << "Si2NoP   = " << normParams->Si2NoP
+              << std::endl;
+    std::cout << printPrefix << "Si2NoJ   = " << normParams->Si2NoJ
+              << std::endl;
+    std::cout << printPrefix << "Si2NoL   = " << normParams->Si2NoL
+              << std::endl;
     std::cout << printPrefix
               << "==================================================="
               << std::endl;

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -103,17 +103,18 @@ void FluidInterface::post_process_param(bool receiveICOnly) {
 
   const Real protonMassPerChargeSI = cProtonMassSI / cUnitChargeSI;
 
-  mNormSI = 1e7 * lNormSI * pow(protonMassPerChargeSI * ScalingFactor, 2);
+  normParams->mNormSI =
+      1e7 * normParams->lNormSI * pow(protonMassPerChargeSI * normParams->ScalingFactor, 2);
 
   // rPlanetSi default set in #NORMALIZATION read_param; only override
   // if it was not already set by #BODYSIZE.
-  if (rPlanetSi == 1.0)
-    rPlanetSi = lNormSI;
+  if (normParams->rPlanetSi == 1.0)
+    normParams->rPlanetSi = normParams->lNormSI;
 
   // This is just a guess. To be improved.
-  MhdNo2SiL = rPlanetSi;
+  normParams->MhdNo2SiL = normParams->rPlanetSi;
 
-  calc_normalization_units();
+  normParams->calc_normalization_units();
 
   if (receiveICOnly)
     return;
@@ -323,10 +324,10 @@ FluidInterface::FluidInterface(Geometry const& gm, AmrInfo const& amrInfo,
 
   n = 0;
   // Normalization parameters.
-  lNormSI = norm[n++];
-  uNormSI = norm[n++];
-  mNormSI = norm[n++];
-  ScalingFactor = norm[n++];
+  normParams->lNormSI = norm[n++];
+  normParams->uNormSI = norm[n++];
+  normParams->mNormSI = norm[n++];
+  normParams->ScalingFactor = norm[n++];
 
   QoQi_S.resize(nS);
   MoMi_S.resize(nS);
@@ -349,11 +350,11 @@ FluidInterface::FluidInterface(Geometry const& gm, AmrInfo const& amrInfo,
   // Electron pressure ratio: Pe/Ptotal
   PeRatio = paramComm[n++];
 
-  rPlanetSi = paramComm[n++];
-  MhdNo2SiL = paramComm[n++];
+  normParams->rPlanetSi = paramComm[n++];
+  normParams->MhdNo2SiL = paramComm[n++];
   /** Do not change the order of above lines. */
 
-  calc_normalization_units();
+  normParams->calc_normalization_units();
 
   calc_conversion_units();
 
@@ -370,12 +371,12 @@ FluidInterface::FluidInterface(Geometry const& gm, AmrInfo const& amrInfo,
 //==========================================================
 void FluidInterface::read_param(const std::string& command, ReadParam& param) {
   if (command == "#NORMALIZATION") {
-    param.read_var("lNorm", lNormSI);
-    param.read_var("uNorm", uNormSI);
+    param.read_var("lNorm", normParams->lNormSI);
+    param.read_var("uNorm", normParams->uNormSI);
   } else if (command == "#SCALINGFACTOR") {
-    param.read_var("scaling", ScalingFactor);
+    param.read_var("scaling", normParams->ScalingFactor);
   } else if (command == "#BODYSIZE") {
-    param.read_var("radius", rPlanetSi);
+    param.read_var("radius", normParams->rPlanetSi);
   } else if (command == "#EXOSPHERE") {
     param.read_var("typeProfile", exosphereType);
     param.read_var("nComponent", nExoComponent);
@@ -762,10 +763,10 @@ void FluidInterface::normalize_fluid_variables() {
   for (int iLev = 0; iLev < n_lev(); iLev++) {
     for (int i = 0; i < nodeFluid[iLev].nComp(); ++i) {
       MultiFab tmpMF(nodeFluid[iLev], make_alias, i, 1);
-      tmpMF.mult(Si2No_V[i], tmpMF.nGrow());
+      tmpMF.mult(normParams->Si2No_V[i], tmpMF.nGrow());
     }
 
-    centerB[iLev].mult(Si2NoB, centerB[iLev].nGrow());
+    centerB[iLev].mult(normParams->Si2NoB, centerB[iLev].nGrow());
   }
 }
 
@@ -803,9 +804,9 @@ void FluidInterface::convert_moment_to_velocity(bool phyNodeOnly, bool doWarn) {
             } else {
               const Real* dx = Geom(iLev).CellSize();
               const auto plo = Geom(iLev).ProbLo();
-              const Real x = (i * dx[ix_] + plo[ix_]) * No2SiL / rPlanetSi;
-              const Real y = (j * dx[iy_] + plo[iy_]) * No2SiL / rPlanetSi;
-              const Real z = (k * dx[iz_] + plo[iz_]) * No2SiL / rPlanetSi;
+              const Real x = (i * dx[ix_] + plo[ix_]) * normParams->No2SiL / normParams->rPlanetSi;
+              const Real y = (j * dx[iy_] + plo[iy_]) * normParams->No2SiL / normParams->rPlanetSi;
+              const Real z = (k * dx[iz_] + plo[iz_]) * normParams->No2SiL / normParams->rPlanetSi;
               if (doWarn) {
                 printf("Warning: ZERO density at x = %e, y = %e, z = %e\n", x,
                        y, z);
@@ -835,32 +836,32 @@ void FluidInterface::set_plasma_charge_and_mass(Real qomEl) {
 void FluidInterface::calc_conversion_units() {
   const int nVar = (useCurrent ? nVarFluid + 3 : nVarFluid);
 
-  Si2No_V.resize(nVar);
-  No2Si_V.resize(nVar);
+  normParams->Si2No_V.resize(nVar);
+  normParams->No2Si_V.resize(nVar);
 
   for (int i = 0; i < nVar; ++i)
-    Si2No_V[i] = 1;
+    normParams->Si2No_V[i] = 1;
 
-  Si2No_V[iBx] = Si2NoB;
-  Si2No_V[iBy] = Si2NoB;
-  Si2No_V[iBz] = Si2NoB;
+  normParams->Si2No_V[iBx] = normParams->Si2NoB;
+  normParams->Si2No_V[iBy] = normParams->Si2NoB;
+  normParams->Si2No_V[iBz] = normParams->Si2NoB;
 
-  if (Si2No_V.size() > iJz) {
-    Si2No_V[iJx] = Si2NoJ;
-    Si2No_V[iJy] = Si2NoJ;
-    Si2No_V[iJz] = Si2NoJ;
+  if (normParams->Si2No_V.size() > iJz) {
+    normParams->Si2No_V[iJx] = normParams->Si2NoJ;
+    normParams->Si2No_V[iJy] = normParams->Si2NoJ;
+    normParams->Si2No_V[iJz] = normParams->Si2NoJ;
   }
 
   if (useElectronFluid && iEx >= 0) {
-    Si2No_V[iEx] = Si2NoE;
-    Si2No_V[iEy] = Si2NoE;
-    Si2No_V[iEz] = Si2NoE;
+    normParams->Si2No_V[iEx] = normParams->Si2NoE;
+    normParams->Si2No_V[iEy] = normParams->Si2NoE;
+    normParams->Si2No_V[iEz] = normParams->Si2NoE;
   }
 
   if (useMhdPe)
-    Si2No_V[iPe] = Si2NoP;
+    normParams->Si2No_V[iPe] = normParams->Si2NoP;
   if (useMultiSpecies)
-    Si2No_V[iRhoTotal] = Si2NoRho;
+    normParams->Si2No_V[iRhoTotal] = normParams->Si2NoRho;
 
   int iMax;
   iMax = nFluid;
@@ -868,43 +869,26 @@ void FluidInterface::calc_conversion_units() {
     iMax = nIon;
 
   for (int i = 0; i < iMax; ++i) {
-    Si2No_V[iRho_I[i]] = Si2NoRho;
-    Si2No_V[iRhoUx_I[i]] = Si2NoM;
-    Si2No_V[iRhoUy_I[i]] = Si2NoM;
-    Si2No_V[iRhoUz_I[i]] = Si2NoM;
-    Si2No_V[iP_I[i]] = Si2NoP;
+    normParams->Si2No_V[iRho_I[i]] = normParams->Si2NoRho;
+    normParams->Si2No_V[iRhoUx_I[i]] = normParams->Si2NoM;
+    normParams->Si2No_V[iRhoUy_I[i]] = normParams->Si2NoM;
+    normParams->Si2No_V[iRhoUz_I[i]] = normParams->Si2NoM;
+    normParams->Si2No_V[iP_I[i]] = normParams->Si2NoP;
     if (useAnisoP)
-      Si2No_V[iPpar_I[i]] = Si2NoP;
+      normParams->Si2No_V[iPpar_I[i]] = normParams->Si2NoP;
   }
 
   if (iLevSet > 0)
-    Si2No_V[iLevSet] = Si2NoRho;
+    normParams->Si2No_V[iLevSet] = normParams->Si2NoRho;
 
   // Get back to SI units
   for (int iVar = 0; iVar < nVar; iVar++)
-    No2Si_V[iVar] = 1.0 / Si2No_V[iVar];
+    normParams->No2Si_V[iVar] = 1.0 / normParams->Si2No_V[iVar];
 }
 
 //-------------------------------------------------------------------------
 
-void FluidInterface::sync_normalization_params(const FluidInterface& other) {
-  // Copy only the normalization base parameters (those that
-  // calc_normalization_units() reads and that fi->post_process_param()
-  // finalizes) and recompute the derived normalization units.  Deliberately
-  // leave nS / MoMi_S / QoQi_S / varNames / iRho_I untouched: secondary
-  // interfaces (OHInterface) manage those themselves (constructor resets
-  // and set_node_fluid -> analyze_var_names).
-  lNormSI = other.lNormSI;
-  uNormSI = other.uNormSI;
-  mNormSI = other.mNormSI;
-  rPlanetSi = other.rPlanetSi;
-  calc_normalization_units();
-}
-
-//-------------------------------------------------------------------------
-
-void FluidInterface::calc_normalization_units() {
-
+void NormalizationParams::calc_normalization_units() {
   // Normalization units converted [SI] -> [cgs]
   if (lNormSI > 0) {
     Lnorm = 100.0 * lNormSI;
@@ -1075,20 +1059,20 @@ void FluidInterface::print_info() const {
     std::cout << printPrefix
               << "============= Normalization factors ============="
               << std::endl;
-    std::cout << printPrefix << "Mnorm    = " << Mnorm << std::endl;
-    std::cout << printPrefix << "Unorm    = " << Unorm << std::endl;
-    std::cout << printPrefix << "Qnorm    = " << Qnorm << std::endl;
-    std::cout << printPrefix << "Lnorm    = " << Lnorm << std::endl;
+    std::cout << printPrefix << "Mnorm    = " << normParams->Mnorm << std::endl;
+    std::cout << printPrefix << "Unorm    = " << normParams->Unorm << std::endl;
+    std::cout << printPrefix << "Qnorm    = " << normParams->Qnorm << std::endl;
+    std::cout << printPrefix << "Lnorm    = " << normParams->Lnorm << std::endl;
     std::cout << printPrefix
               << "========== Unit conversion factors =============="
               << std::endl;
-    std::cout << printPrefix << "Si2NoRho = " << Si2NoRho << std::endl;
-    std::cout << printPrefix << "Si2NoV   = " << Si2NoV << std::endl;
-    std::cout << printPrefix << "Si2NoB   = " << Si2NoB << std::endl;
-    std::cout << printPrefix << "Si2NoE   = " << Si2NoE << std::endl;
-    std::cout << printPrefix << "Si2NoP   = " << Si2NoP << std::endl;
-    std::cout << printPrefix << "Si2NoJ   = " << Si2NoJ << std::endl;
-    std::cout << printPrefix << "Si2NoL   = " << Si2NoL << std::endl;
+    std::cout << printPrefix << "Si2NoRho = " << normParams->Si2NoRho << std::endl;
+    std::cout << printPrefix << "Si2NoV   = " << normParams->Si2NoV << std::endl;
+    std::cout << printPrefix << "Si2NoB   = " << normParams->Si2NoB << std::endl;
+    std::cout << printPrefix << "Si2NoE   = " << normParams->Si2NoE << std::endl;
+    std::cout << printPrefix << "Si2NoP   = " << normParams->Si2NoP << std::endl;
+    std::cout << printPrefix << "Si2NoJ   = " << normParams->Si2NoJ << std::endl;
+    std::cout << printPrefix << "Si2NoL   = " << normParams->Si2NoL << std::endl;
     std::cout << printPrefix
               << "==================================================="
               << std::endl;

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -105,8 +105,7 @@ void FluidInterface::post_process_param(bool receiveICOnly) {
 
   const Real protonMassPerChargeSI = cProtonMassSI / cUnitChargeSI;
 
-  mNormSI =
-      1e7 * lNormSI * pow(protonMassPerChargeSI * ScalingFactor, 2);
+  mNormSI = 1e7 * lNormSI * pow(protonMassPerChargeSI * ScalingFactor, 2);
 
   // rPlanetSi default set in #NORMALIZATION read_param; only override
   // if it was not already set by #BODYSIZE.
@@ -117,7 +116,7 @@ void FluidInterface::post_process_param(bool receiveICOnly) {
   MhdNo2SiL = rPlanetSi;
 
   if (receiveICOnly) {
-    finalize_normalization(true);   // publish scalars only (vectors not yet set)
+    finalize_normalization(true); // publish scalars only (vectors not yet set)
     return;
   }
 
@@ -913,8 +912,11 @@ void FluidInterface::finalize_normalization(bool scalarOnly) {
 //-----------------------------------------------------------------------
 NormalizationParams::NormalizationParams(const FluidInterface& fi,
                                          bool scalarOnly)
-    : rPlanetSi(fi.rPlanetSi), ScalingFactor(fi.ScalingFactor),
-      uNormSI(fi.uNormSI), mNormSI(fi.mNormSI), MhdNo2SiL(fi.MhdNo2SiL) {
+    : rPlanetSi(fi.rPlanetSi),
+      ScalingFactor(fi.ScalingFactor),
+      uNormSI(fi.uNormSI),
+      mNormSI(fi.mNormSI),
+      MhdNo2SiL(fi.MhdNo2SiL) {
   calc_normalization_units(fi.lNormSI, fi.uNormSI, fi.mNormSI);
   if (!scalarOnly)
     compute_var_conversions(fi);
@@ -922,7 +924,8 @@ NormalizationParams::NormalizationParams(const FluidInterface& fi,
 
 //-------------------------------------------------------------------------
 
-void NormalizationParams::calc_normalization_units(double lNormSI, double uNormSI,
+void NormalizationParams::calc_normalization_units(double lNormSI,
+                                                   double uNormSI,
                                                    double mNormSI) {
   // Normalization units converted [SI] -> [cgs]
   if (lNormSI > 0) {

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -89,7 +89,9 @@ void FluidInterface::analyze_var_names(bool useNeutralOnly) {
   iRhoUy_I = iUy_I;
   iRhoUz_I = iUz_I;
 
-  calc_conversion_units();
+  // Variable indices are now known; (re)build the immutable normalization
+  // instance with the per-variable conversion vectors filled in.
+  finalize_normalization();
   QoQi_S.resize(nS);
   MoMi_S.resize(nS);
   nodeFluid.clear();
@@ -103,22 +105,21 @@ void FluidInterface::post_process_param(bool receiveICOnly) {
 
   const Real protonMassPerChargeSI = cProtonMassSI / cUnitChargeSI;
 
-  normParams->mNormSI =
-      1e7 * normParams->lNormSI *
-      pow(protonMassPerChargeSI * normParams->ScalingFactor, 2);
+  mNormSI =
+      1e7 * lNormSI * pow(protonMassPerChargeSI * ScalingFactor, 2);
 
   // rPlanetSi default set in #NORMALIZATION read_param; only override
   // if it was not already set by #BODYSIZE.
-  if (normParams->rPlanetSi == 1.0)
-    normParams->rPlanetSi = normParams->lNormSI;
+  if (rPlanetSi == 1.0)
+    rPlanetSi = lNormSI;
 
   // This is just a guess. To be improved.
-  normParams->MhdNo2SiL = normParams->rPlanetSi;
+  MhdNo2SiL = rPlanetSi;
 
-  normParams->calc_normalization_units();
-
-  if (receiveICOnly)
+  if (receiveICOnly) {
+    finalize_normalization(true);   // publish scalars only (vectors not yet set)
     return;
+  }
 
   iRho_I.resize(nS);
   iRhoUx_I.resize(nS);
@@ -211,7 +212,9 @@ void FluidInterface::post_process_param(bool receiveICOnly) {
            iJx, iJy, iJz);
   }
 
-  calc_conversion_units();
+  // Compute derived normalization + per-variable conversion factors and
+  // publish the frozen instance shared by all secondary interfaces.
+  finalize_normalization();
 }
 
 FluidInterface::FluidInterface(Geometry const& gm, AmrInfo const& amrInfo,
@@ -325,10 +328,10 @@ FluidInterface::FluidInterface(Geometry const& gm, AmrInfo const& amrInfo,
 
   n = 0;
   // Normalization parameters.
-  normParams->lNormSI = norm[n++];
-  normParams->uNormSI = norm[n++];
-  normParams->mNormSI = norm[n++];
-  normParams->ScalingFactor = norm[n++];
+  lNormSI = norm[n++];
+  uNormSI = norm[n++];
+  mNormSI = norm[n++];
+  ScalingFactor = norm[n++];
 
   QoQi_S.resize(nS);
   MoMi_S.resize(nS);
@@ -351,13 +354,13 @@ FluidInterface::FluidInterface(Geometry const& gm, AmrInfo const& amrInfo,
   // Electron pressure ratio: Pe/Ptotal
   PeRatio = paramComm[n++];
 
-  normParams->rPlanetSi = paramComm[n++];
-  normParams->MhdNo2SiL = paramComm[n++];
+  rPlanetSi = paramComm[n++];
+  MhdNo2SiL = paramComm[n++];
   /** Do not change the order of above lines. */
 
-  normParams->calc_normalization_units();
-
-  calc_conversion_units();
+  // Publish the frozen normalization instance shared by all secondary
+  // interfaces (source, OHInterface, ...).
+  finalize_normalization();
 
   if (useMultiFluid && !useMhdPe) {
     std::cout << printPrefix
@@ -372,12 +375,25 @@ FluidInterface::FluidInterface(Geometry const& gm, AmrInfo const& amrInfo,
 //==========================================================
 void FluidInterface::read_param(const std::string& command, ReadParam& param) {
   if (command == "#NORMALIZATION") {
-    param.read_var("lNorm", normParams->lNormSI);
-    param.read_var("uNorm", normParams->uNormSI);
+    const double lOld = lNormSI, uOld = uNormSI;
+    param.read_var("lNorm", lNormSI);
+    param.read_var("uNorm", uNormSI);
+    // In SWMF/OH-PT mode the variable indices are already known (set in the
+    // ctor), so an explicit override can be re-finalized immediately; the OH
+    // interfaces then share a consistent instance via the
+    // FluidInterfaceParameters copy constructor.
+    if ((lNormSI != lOld || uNormSI != uOld) && initFromSWMF)
+      finalize_normalization();
   } else if (command == "#SCALINGFACTOR") {
-    param.read_var("scaling", normParams->ScalingFactor);
+    const int sOld = ScalingFactor;
+    param.read_var("scaling", ScalingFactor);
+    if (ScalingFactor != sOld && initFromSWMF)
+      finalize_normalization();
   } else if (command == "#BODYSIZE") {
-    param.read_var("radius", normParams->rPlanetSi);
+    const double rOld = rPlanetSi;
+    param.read_var("radius", rPlanetSi);
+    if (rPlanetSi != rOld && initFromSWMF)
+      finalize_normalization();
   } else if (command == "#EXOSPHERE") {
     param.read_var("typeProfile", exosphereType);
     param.read_var("nComponent", nExoComponent);
@@ -837,62 +853,77 @@ void FluidInterface::set_plasma_charge_and_mass(Real qomEl) {
 }
 
 //-----------------------------------------------------------------------
-void FluidInterface::calc_conversion_units() {
-  const int nVar = (useCurrent ? nVarFluid + 3 : nVarFluid);
-
-  normParams->Si2No_V.resize(nVar);
-  normParams->No2Si_V.resize(nVar);
+void NormalizationParams::compute_var_conversions(const FluidInterface& fi) {
+  const int nVar = (fi.useCurrent ? fi.nVarFluid + 3 : fi.nVarFluid);
+  Si2No_V.resize(nVar);
+  No2Si_V.resize(nVar);
 
   for (int i = 0; i < nVar; ++i)
-    normParams->Si2No_V[i] = 1;
+    Si2No_V[i] = 1;
 
-  normParams->Si2No_V[iBx] = normParams->Si2NoB;
-  normParams->Si2No_V[iBy] = normParams->Si2NoB;
-  normParams->Si2No_V[iBz] = normParams->Si2NoB;
+  Si2No_V[fi.iBx] = Si2NoB;
+  Si2No_V[fi.iBy] = Si2NoB;
+  Si2No_V[fi.iBz] = Si2NoB;
 
-  if (normParams->Si2No_V.size() > iJz) {
-    normParams->Si2No_V[iJx] = normParams->Si2NoJ;
-    normParams->Si2No_V[iJy] = normParams->Si2NoJ;
-    normParams->Si2No_V[iJz] = normParams->Si2NoJ;
+  if (Si2No_V.size() > fi.iJz) {
+    Si2No_V[fi.iJx] = Si2NoJ;
+    Si2No_V[fi.iJy] = Si2NoJ;
+    Si2No_V[fi.iJz] = Si2NoJ;
   }
 
-  if (useElectronFluid && iEx >= 0) {
-    normParams->Si2No_V[iEx] = normParams->Si2NoE;
-    normParams->Si2No_V[iEy] = normParams->Si2NoE;
-    normParams->Si2No_V[iEz] = normParams->Si2NoE;
+  if (fi.useElectronFluid && fi.iEx >= 0) {
+    Si2No_V[fi.iEx] = Si2NoE;
+    Si2No_V[fi.iEy] = Si2NoE;
+    Si2No_V[fi.iEz] = Si2NoE;
   }
 
-  if (useMhdPe)
-    normParams->Si2No_V[iPe] = normParams->Si2NoP;
-  if (useMultiSpecies)
-    normParams->Si2No_V[iRhoTotal] = normParams->Si2NoRho;
+  if (fi.useMhdPe)
+    Si2No_V[fi.iPe] = Si2NoP;
+  if (fi.useMultiSpecies)
+    Si2No_V[fi.iRhoTotal] = Si2NoRho;
 
   int iMax;
-  iMax = nFluid;
-  if (useMultiSpecies)
-    iMax = nIon;
+  iMax = fi.nFluid;
+  if (fi.useMultiSpecies)
+    iMax = fi.nIon;
 
   for (int i = 0; i < iMax; ++i) {
-    normParams->Si2No_V[iRho_I[i]] = normParams->Si2NoRho;
-    normParams->Si2No_V[iRhoUx_I[i]] = normParams->Si2NoM;
-    normParams->Si2No_V[iRhoUy_I[i]] = normParams->Si2NoM;
-    normParams->Si2No_V[iRhoUz_I[i]] = normParams->Si2NoM;
-    normParams->Si2No_V[iP_I[i]] = normParams->Si2NoP;
-    if (useAnisoP)
-      normParams->Si2No_V[iPpar_I[i]] = normParams->Si2NoP;
+    Si2No_V[fi.iRho_I[i]] = Si2NoRho;
+    Si2No_V[fi.iRhoUx_I[i]] = Si2NoM;
+    Si2No_V[fi.iRhoUy_I[i]] = Si2NoM;
+    Si2No_V[fi.iRhoUz_I[i]] = Si2NoM;
+    Si2No_V[fi.iP_I[i]] = Si2NoP;
+    if (fi.useAnisoP)
+      Si2No_V[fi.iPpar_I[i]] = Si2NoP;
   }
 
-  if (iLevSet > 0)
-    normParams->Si2No_V[iLevSet] = normParams->Si2NoRho;
+  if (fi.iLevSet > 0)
+    Si2No_V[fi.iLevSet] = Si2NoRho;
 
   // Get back to SI units
   for (int iVar = 0; iVar < nVar; iVar++)
-    normParams->No2Si_V[iVar] = 1.0 / normParams->Si2No_V[iVar];
+    No2Si_V[iVar] = 1.0 / Si2No_V[iVar];
+}
+
+//-----------------------------------------------------------------------
+void FluidInterface::finalize_normalization(bool scalarOnly) {
+  normParams = std::make_shared<const NormalizationParams>(*this, scalarOnly);
+}
+
+//-----------------------------------------------------------------------
+NormalizationParams::NormalizationParams(const FluidInterface& fi,
+                                         bool scalarOnly)
+    : rPlanetSi(fi.rPlanetSi), ScalingFactor(fi.ScalingFactor),
+      uNormSI(fi.uNormSI), mNormSI(fi.mNormSI), MhdNo2SiL(fi.MhdNo2SiL) {
+  calc_normalization_units(fi.lNormSI, fi.uNormSI, fi.mNormSI);
+  if (!scalarOnly)
+    compute_var_conversions(fi);
 }
 
 //-------------------------------------------------------------------------
 
-void NormalizationParams::calc_normalization_units() {
+void NormalizationParams::calc_normalization_units(double lNormSI, double uNormSI,
+                                                   double mNormSI) {
   // Normalization units converted [SI] -> [cgs]
   if (lNormSI > 0) {
     Lnorm = 100.0 * lNormSI;

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -97,7 +97,7 @@ void FluidInterface::analyze_var_names(bool useNeutralOnly) {
   nodeFluid.clear();
 }
 
-void FluidInterface::post_process_param(const DomainParameters &parameters) {
+void FluidInterface::post_process_param(const DomainParameters& parameters) {
   if (initFromSWMF)
     return;
 
@@ -821,10 +821,10 @@ void FluidInterface::convert_moment_to_velocity(bool phyNodeOnly, bool doWarn) {
                              normParams->rPlanetSi;
               const Real y = (j * dx[iy_] + plo[iy_]) * normParams->No2SiL /
                              normParams->rPlanetSi;
-              const Real z = nDimFluid > 2
-                                 ? (k * dx[iz_] + plo[iz_]) * normParams->No2SiL /
-                                       normParams->rPlanetSi
-                                 : 0.0;
+              const Real z = nDimFluid > 2 ? (k * dx[iz_] + plo[iz_]) *
+                                                 normParams->No2SiL /
+                                                 normParams->rPlanetSi
+                                           : 0.0;
               if (doWarn) {
                 printf("Warning: ZERO density at x = %e, y = %e, z = %e\n", x,
                        y, z);

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -97,7 +97,7 @@ void FluidInterface::analyze_var_names(bool useNeutralOnly) {
   nodeFluid.clear();
 }
 
-void FluidInterface::post_process_param(bool receiveICOnly) {
+void FluidInterface::post_process_param(const DomainParameters &parameters) {
   if (initFromSWMF)
     return;
 
@@ -115,7 +115,7 @@ void FluidInterface::post_process_param(bool receiveICOnly) {
   // This is just a guess. To be improved.
   MhdNo2SiL = rPlanetSi;
 
-  if (receiveICOnly) {
+  if (parameters.receiveICOnly) {
     finalize_normalization(true); // publish scalars only (vectors not yet set)
     return;
   }

--- a/src/FluidInterface.cpp
+++ b/src/FluidInterface.cpp
@@ -817,13 +817,12 @@ void FluidInterface::convert_moment_to_velocity(bool phyNodeOnly, bool doWarn) {
             } else {
               const Real* dx = Geom(iLev).CellSize();
               const auto plo = Geom(iLev).ProbLo();
-              const Real x = (i * dx[ix_] + plo[ix_]) * normParams->No2SiL /
-                             normParams->rPlanetSi;
-              const Real y = (j * dx[iy_] + plo[iy_]) * normParams->No2SiL /
-                             normParams->rPlanetSi;
+              const Real x =
+                  (i * dx[ix_] + plo[ix_]) * normParams->No2SiL / rPlanetSi;
+              const Real y =
+                  (j * dx[iy_] + plo[iy_]) * normParams->No2SiL / rPlanetSi;
               const Real z = nDimFluid > 2 ? (k * dx[iz_] + plo[iz_]) *
-                                                 normParams->No2SiL /
-                                                 normParams->rPlanetSi
+                                                 normParams->No2SiL / rPlanetSi
                                            : 0.0;
               if (doWarn) {
                 printf("Warning: ZERO density at x = %e, y = %e, z = %e\n", x,
@@ -910,12 +909,7 @@ void FluidInterface::finalize_normalization(bool scalarOnly) {
 
 //-----------------------------------------------------------------------
 NormalizationParams::NormalizationParams(const FluidInterface& fi,
-                                         bool scalarOnly)
-    : rPlanetSi(fi.rPlanetSi),
-      ScalingFactor(fi.ScalingFactor),
-      uNormSI(fi.uNormSI),
-      mNormSI(fi.mNormSI),
-      MhdNo2SiL(fi.MhdNo2SiL) {
+                                         bool scalarOnly) {
   calc_normalization_units(fi.lNormSI, fi.uNormSI, fi.mNormSI);
   if (!scalarOnly)
     compute_var_conversions(fi);

--- a/src/ParticleTracker.cpp
+++ b/src/ParticleTracker.cpp
@@ -12,11 +12,11 @@ void ParticleTracker::set_ic(Pic& pic) {
 
   for (int i = 0; i < parts.size(); ++i) {
     auto& tps = parts[i];
-    if (doInitFromPIC) {
-      tps->read_test_particle_list(listFiles);
+    if (pInfo->doInitFromPIC) {
+      tps->read_test_particle_list(pInfo->listFiles);
       tps->add_test_particles_from_pic(pic.get_particle_pointer(i));
     } else {
-      tps->add_test_particles_from_fluid(tpStates);
+      tps->add_test_particles_from_fluid(pInfo->tpStates);
     }
     tps->update_initial_particle_number();
 
@@ -104,7 +104,7 @@ void ParticleTracker::update(Pic& pic, bool doReport) {
     for (int iLev = 0; iLev < n_lev(); iLev++) {
       tps->move_and_save_particles(nodeE[iLev], nodeB[iLev], tc->get_dt(),
                                    tc->get_next_dt(), tc->get_time_si(),
-                                   tc->get_cycle() % dnSave[i] == 0);
+                                   tc->get_cycle() % pInfo->dnSave[i] == 0);
     }
 
     if (doSave) {
@@ -117,11 +117,11 @@ void ParticleTracker::update(Pic& pic, bool doReport) {
       tps->write_particles(tc->get_cycle());
 
       // Refill test particles if necessary.
-      if (doInitFromPIC) {
+      if (pInfo->doInitFromPIC) {
         tps->add_test_particles_from_pic(pic.get_particle_pointer(i));
       } else if (tps->TotalNumberOfParticles() <
-                 launchThreshold[i] * tps->init_particle_number()) {
-        tps->add_test_particles_from_fluid(tpStates);
+                 pInfo->launchThreshold[i] * tps->init_particle_number()) {
+        tps->add_test_particles_from_fluid(pInfo->tpStates);
       }
     }
   }
@@ -137,10 +137,11 @@ void ParticleTracker::update_field(Pic& pic) {
 }
 
 void ParticleTracker::post_process_param() {
-  int min_dnSave = dnSave[0];
+  nSpecies = fi->get_nS();
+  int min_dnSave = pInfo->dnSave[0];
   for (int i = 1; i < nSpecies; ++i) {
-    if (dnSave[i] < min_dnSave) {
-      min_dnSave = dnSave[i];
+    if (pInfo->dnSave[i] < min_dnSave) {
+      min_dnSave = pInfo->dnSave[i];
     }
   }
   savectr = std::make_unique<PlotCtr>(ParallelDescriptor::Communicator(), tc,
@@ -177,15 +178,17 @@ void ParticleTracker::post_regrid() {
   distribute_grid_arrays();
 
   //--------------test particles-----------------------------------
+  nSpecies = fi->get_nS();
+
   if (parts.empty()) {
     for (int i = 0; i < nSpecies; ++i) {
       auto ptr = std::make_unique<TestParticles>(
           this, fi, tc, i, fi->get_species_charge(i), fi->get_species_mass(i),
           gridID);
-      ptr->set_ppc(nTPPerCell);
-      ptr->set_interval(nTPIntervalCell);
-      ptr->set_particle_region(sRegion, tpShapes);
-      ptr->set_relativistic(isRelativistic);
+      ptr->set_ppc(pInfo->nTPPerCell);
+      ptr->set_interval(pInfo->nTPIntervalCell);
+      ptr->set_particle_region(pInfo->sRegion, tpShapes);
+      ptr->set_relativistic(pInfo->isRelativistic);
       parts.push_back(std::move(ptr));
     }
     Print() << gridName << " pt: Number of test particle species: " << nSpecies
@@ -193,7 +196,7 @@ void ParticleTracker::post_regrid() {
     Print() << gridName
             << " pt: TPSAVE parameters (nPTRecord, ptRecordSize): " << nPTRecord
             << ", " << ptRecordSize << std::endl;
-    Print() << gridName << " pt: TPREGION: " << sRegion << std::endl;
+    Print() << gridName << " pt: TPREGION: " << pInfo->sRegion << std::endl;
   } else {
     for (int i = 0; i < nSpecies; ++i) {
       // Label the particles outside the NEW PIC region.
@@ -235,7 +238,10 @@ void ParticleTracker::read_restart() {
     parts[iPart]->Restart(restartDir,
                           gridName + "_test_particles" + std::to_string(iPart));
     parts[iPart]->reset_record_counter();
-    parts[iPart]->init_particle_number(initPartNumber[iPart]);
+    if (iPart < (int)pInfo->initPartNumber.size())
+      parts[iPart]->init_particle_number(pInfo->initPartNumber[iPart]);
+    else
+      parts[iPart]->init_particle_number(0);
   }
   complete_parameters();
 }
@@ -249,7 +255,7 @@ void ParticleTracker::complete_parameters() {
   }
 
   // Pass information to writers.
-  writer.set_plotString("3d fluid test_particle real4 " + sIOUnit);
+  writer.set_plotString("3d fluid test_particle real4 " + pInfo->sIOUnit);
   writer.set_nDim(fi->get_fluid_dimension());
   writer.set_units(fi->get_No2SiL(), fi->get_No2SiV(), fi->get_No2SiB(),
                    fi->get_No2SiRho(), fi->get_No2SiP(), fi->get_No2SiJ(),
@@ -277,64 +283,4 @@ void ParticleTracker::save_restart_header(std::ofstream& headerFile) {
   }
 }
 
-void ParticleTracker::read_param(const std::string& command, ReadParam& param) {
 
-  if (command == "#TPPARTICLES") {
-    param.read_var("npcelx", nTPPerCell[ix_]);
-    param.read_var("npcely", nTPPerCell[iy_]);
-    if (nDim == 3)
-      param.read_var("npcelz", nTPPerCell[iz_]);
-  } else if (command == "#TPCELLINTERVAL") {
-    param.read_var("nIntervalX", nTPIntervalCell[ix_]);
-    param.read_var("nIntervalY", nTPIntervalCell[iy_]);
-    if (nDim == 3)
-      param.read_var("nIntervalZ", nTPIntervalCell[iz_]);
-  } else if (command == "#TPREGION") {
-    param.read_var("region", sRegion);
-  } else if (command == "#TPSAVE") {
-    int iSpecies;
-    param.read_var("iSpecies", iSpecies);
-    if (iSpecies >= nSpecies)
-      amrex::Abort("Error: iSpecies is out of bound in #TPSAVE.");
-    param.read_var("IOUnit", sIOUnit);
-    param.read_var("dnSave", dnSave[iSpecies]);
-    param.read_var("launchThreshold", launchThreshold[iSpecies]);
-  } else if (command == "#TPRELATIVISTIC") {
-    param.read_var("isRelativistic", isRelativistic);
-  } else if (command == "#TPSTATESI") {
-    double si2noV = fi->get_Si2NoV();
-    int nState;
-    param.read_var("nState", nState);
-    for (int i = 0; i < nState; ++i) {
-      Vel state;
-      param.read_var("iSpecies", state.tag);
-      param.read_var("vth", state.vth);
-      param.read_var("vx", state.vx);
-      param.read_var("vy", state.vy);
-      param.read_var("vz", state.vz);
-      state.vth *= si2noV;
-      state.vx *= si2noV;
-      state.vy *= si2noV;
-      state.vz *= si2noV;
-      tpStates.push_back(state);
-    }
-  } else if (command == "#TPINITFROMPIC") {
-    param.read_var("doInitFromPIC", doInitFromPIC);
-    if (doInitFromPIC) {
-      int nList;
-      param.read_var("nList", nList);
-      for (int i = 0; i < nList; ++i) {
-        std::string s;
-        param.read_var("list", s);
-        listFiles.push_back(s);
-      }
-    }
-  } else if (command == "#TESTPARTICLENUMBER") {
-    initPartNumber.clear();
-    unsigned long int num;
-    for (int iPart = 0; iPart < nSpecies; iPart++) {
-      param.read_var("Number", num);
-      initPartNumber.push_back(num);
-    }
-  }
-}

--- a/src/ParticleTracker.cpp
+++ b/src/ParticleTracker.cpp
@@ -49,7 +49,7 @@ void ParticleTracker::write_log(bool doForce, bool doCreateFile) {
     logFile = ss.str();
     std::ofstream of(logFile.c_str());
     of << "time nStep";
-    for (int i = 0; i < nSpecies; ++i)
+    for (int i = 0; i < parts.size(); ++i)
       of << " mass_" << i << " moment_x_" << i << " moment_y_" << i
          << " moment_z_" << i << " energy_" << i;
 
@@ -137,7 +137,7 @@ void ParticleTracker::update_field(Pic& pic) {
 }
 
 void ParticleTracker::post_process_param() {
-  nSpecies = fi->get_nS();
+  const int nSpecies = fi->get_nS();
   int min_dnSave = pInfo->dnSave[0];
   for (int i = 1; i < nSpecies; ++i) {
     if (pInfo->dnSave[i] < min_dnSave) {
@@ -151,7 +151,7 @@ void ParticleTracker::post_process_param() {
 
 void ParticleTracker::pre_regrid() {
   if (!parts.empty()) {
-    for (int i = 0; i < nSpecies; ++i) {
+    for (int i = 0; i < parts.size(); ++i) {
       // Label the particles outside the OLD PIC region. It should be called
       // before active region is updated.
       parts[i]->label_particles_outside_active_region();
@@ -178,7 +178,7 @@ void ParticleTracker::post_regrid() {
   distribute_grid_arrays();
 
   //--------------test particles-----------------------------------
-  nSpecies = fi->get_nS();
+  const int nSpecies = fi->get_nS();
 
   if (parts.empty()) {
     for (int i = 0; i < nSpecies; ++i) {

--- a/src/ParticleTracker.cpp
+++ b/src/ParticleTracker.cpp
@@ -282,5 +282,3 @@ void ParticleTracker::save_restart_header(std::ofstream& headerFile) {
     headerFile << "\n";
   }
 }
-
-

--- a/src/Pic.cpp
+++ b/src/Pic.cpp
@@ -986,9 +986,9 @@ void Pic::calc_mach_number() {
 }
 
 //==========================================================
-void Pic::calc_cost_per_cell(const DomainParameters &parameters) {
-  const BalanceStrategy balanceStrategy = parameters.balanceStrategy;
-  const int cellWeight = parameters.cellWeight;
+void Pic::calc_cost_per_cell() {
+  const BalanceStrategy balanceStrategy = parameters_.balanceStrategy;
+  const int cellWeight = parameters_.cellWeight;
   if (!isMomentsUpdated && balanceStrategy == BalanceStrategy::Particle) {
     sum_moments(false);
   }

--- a/src/Pic.cpp
+++ b/src/Pic.cpp
@@ -987,8 +987,8 @@ void Pic::calc_mach_number() {
 
 //==========================================================
 void Pic::calc_cost_per_cell() {
-  const BalanceStrategy balanceStrategy = parameters_.balanceStrategy;
-  const int cellWeight = parameters_.cellWeight;
+  const BalanceStrategy balanceStrategy = domainParameters.balanceStrategy;
+  const int cellWeight = domainParameters.cellWeight;
   if (!isMomentsUpdated && balanceStrategy == BalanceStrategy::Particle) {
     sum_moments(false);
   }

--- a/src/Pic.cpp
+++ b/src/Pic.cpp
@@ -986,7 +986,9 @@ void Pic::calc_mach_number() {
 }
 
 //==========================================================
-void Pic::calc_cost_per_cell(BalanceStrategy balanceStrategy, int cellWeight) {
+void Pic::calc_cost_per_cell(const DomainParameters &parameters) {
+  const BalanceStrategy balanceStrategy = parameters.balanceStrategy;
+  const int cellWeight = parameters.cellWeight;
   if (!isMomentsUpdated && balanceStrategy == BalanceStrategy::Particle) {
     sum_moments(false);
   }

--- a/userfiles/DefaultSource.h
+++ b/userfiles/DefaultSource.h
@@ -6,8 +6,8 @@
 class UserSource : public SourceInterface {
 public:
   UserSource(const FluidInterface& other, int id, std::string tag,
-             FluidType typeIn = SourceFluid)
-      : SourceInterface(other, id, tag, typeIn) {
+             FluidType typeIn, const DomainParameters& dp)
+      : SourceInterface(other, id, tag, typeIn, dp) {
     info = "Empty user source class";
   }
 };

--- a/userfiles/ExoSource.h
+++ b/userfiles/ExoSource.h
@@ -16,25 +16,25 @@ public:
 
   double get_exosphere_density(double r) const override {
     if (exosphereType == "None") return 0.0;
-    if (r < normParams->rPlanetSi) return 0.0;
+    if (r < get_rPlanet_SI()) return 0.0;
 
     double sum = 0.0;
     if (exosphereType == "Exponential") {
       for (int i = 0; i < nExoComponent; ++i) {
         if (exoH0[i] > 0.0) {
-          sum += exoN0[i] * exp(-(r - normParams->rPlanetSi) / exoH0[i]);
+          sum += exoN0[i] * exp(-(r - get_rPlanet_SI()) / exoH0[i]);
         }
       }
     } else if (exosphereType == "Power-Law") {
       for (int i = 0; i < nExoComponent; ++i) {
         if (r > 0.0) {
-          sum += exoN0[i] * pow(normParams->rPlanetSi / r, exoK0[i]);
+          sum += exoN0[i] * pow(get_rPlanet_SI() / r, exoK0[i]);
         }
       }
     } else if (exosphereType == "Chamberlain") {
       for (int i = 0; i < nExoComponent; ++i) {
-        if (normParams->rPlanetSi > 0.0 && r > 0.0) {
-          sum += exoN0[i] * exp(-exoH0[i] * (1.0 / normParams->rPlanetSi - 1.0 / r));
+        if (get_rPlanet_SI() > 0.0 && r > 0.0) {
+          sum += exoN0[i] * exp(-exoH0[i] * (1.0 / get_rPlanet_SI() - 1.0 / r));
         }
       }
     }
@@ -45,19 +45,19 @@ public:
                                          int iC) const override {
     if (exosphereType == "None") return 0.0;
     if (iC < 0 || iC >= nExoComponent) return 0.0;
-    if (r < normParams->rPlanetSi) return 0.0;
+    if (r < get_rPlanet_SI()) return 0.0;
 
     if (exosphereType == "Exponential") {
       if (exoH0[iC] > 0.0) {
-        return exoN0[iC] * exp(-(r - normParams->rPlanetSi) / exoH0[iC]);
+        return exoN0[iC] * exp(-(r - get_rPlanet_SI()) / exoH0[iC]);
       }
     } else if (exosphereType == "Power-Law") {
       if (r > 0.0) {
-        return exoN0[iC] * pow(normParams->rPlanetSi / r, exoK0[iC]);
+        return exoN0[iC] * pow(get_rPlanet_SI() / r, exoK0[iC]);
       }
     } else if (exosphereType == "Chamberlain") {
-      if (normParams->rPlanetSi > 0.0 && r > 0.0) {
-        return exoN0[iC] * exp(-exoH0[iC] * (1.0 / normParams->rPlanetSi - 1.0 / r));
+      if (get_rPlanet_SI() > 0.0 && r > 0.0) {
+        return exoN0[iC] * exp(-exoH0[iC] * (1.0 / get_rPlanet_SI() - 1.0 / r));
       }
     }
     return 0.0;
@@ -113,7 +113,7 @@ public:
     if (is_in_shadow(xyz[0], xyz[1], xyz[2])) return 0.0;
     double r2 = xyz[0] * xyz[0] + xyz[1] * xyz[1] + xyz[2] * xyz[2];
     double r_m = sqrt(r2);
-    double ratio = normParams->rPlanetSi / r_m;
+    double ratio = get_rPlanet_SI() / r_m;
     // Geometric dilution: nu = nu0 * (r_planet / r)^2
     return photoNu0[iC] * ratio * ratio;
   }
@@ -391,7 +391,7 @@ public:
     if (rxn.rateType == 1) {
       // Photoionization: rate = nu0 * (Rp/r)^2 [s^-1]
       if (is_in_shadow(xyz[0], xyz[1], xyz[2])) return 0.0;
-      double ratio = normParams->rPlanetSi / r_val;
+      double ratio = get_rPlanet_SI() / r_val;
       return rxn.rateCoef * ratio * ratio;
     }
 
@@ -410,8 +410,8 @@ public:
     }
 
     // Recombination: rate = k * n_e [s^-1]
-    // ne is normalized; convert to SI: n_si = n_norm / (normParams->Si2NoRho * mp)
-    return k_si * ne / (normParams->Si2NoRho * cProtonMassSI);
+    // ne is normalized; convert to SI: n_si = n_norm / (get_Si2NoRho() * mp)
+    return k_si * ne / (get_Si2NoRho() * cProtonMassSI);
   }
 
   //-------------------------------------------------------------------
@@ -444,9 +444,9 @@ public:
       double mass_reac = get_species_mass(iSpReac);
       // Normalized number density: n_norm = rho_norm / mass_amu
       double n_reac_norm = rho_reac_norm / mass_reac;
-      // Convert to SI: n_si = n_norm / (normParams->Si2NoRho * cProtonMassSI)
+      // Convert to SI: n_si = n_norm / (get_Si2NoRho() * cProtonMassSI)
       double n_reac_si =
-          n_reac_norm / (normParams->Si2NoRho * cProtonMassSI);
+          n_reac_norm / (get_Si2NoRho() * cProtonMassSI);
 
       // Source mass density rate (SI): srcRho = rate * n_si * m_prod * mp
       double srcRho_si =
@@ -466,7 +466,7 @@ public:
       // product: srcP = rate * P_reac (SI) [Pa/s].
       double p_reac_norm =
           other.get_value(mfi, idx, iP_I[iSpReac], iLev);
-      double p_reac_si = p_reac_norm / normParams->Si2NoP;
+      double p_reac_si = p_reac_norm / get_Si2NoP();
       srcP[iSpProd] += rate * p_reac_si;
     } else {
       // Photoionization: source from neutral at rest (zero velocity).
@@ -534,12 +534,12 @@ public:
 
       // Loss rate (normalized):
       // lossRho_si = k_si * ne_si * rho_ion_si
-      // lossRho_norm = lossRho_si * normParams->Si2NoRho / Si2NoT
-      //             = k_si * [ne/(normParams->Si2NoRho*mp)] * [rho_norm/normParams->Si2NoRho] *
-      //               normParams->Si2NoRho / Si2NoT
-      //             = k_si * ne * rho_norm / (normParams->Si2NoRho * mp * Si2NoT)
+      // lossRho_norm = lossRho_si * get_Si2NoRho() / Si2NoT
+      //             = k_si * [ne/(get_Si2NoRho()*mp)] * [rho_norm/get_Si2NoRho()] *
+      //               get_Si2NoRho() / Si2NoT
+      //             = k_si * ne * rho_norm / (get_Si2NoRho() * mp * Si2NoT)
       double lossRho_norm = k_si * ne * rho_ion_norm /
-          (normParams->Si2NoRho * cProtonMassSI * get_Si2NoT());
+          (get_Si2NoRho() * cProtonMassSI * get_Si2NoT());
       if (lossRho_norm > 0.0) {
         lossArr(i, j, k, iIon) = lossRho_norm;
       }
@@ -696,23 +696,23 @@ public:
                 for (int iSp = 1; iSp <= nIonS; ++iSp) {
                   if (srcRho[iSp] > 0) {
                     anySource = true;
-                    double rho_norm = srcRho[iSp] * normParams->Si2NoRho / get_Si2NoT();
+                    double rho_norm = srcRho[iSp] * get_Si2NoRho() / get_Si2NoT();
                     arr(i, j, k, iRho_I[iSp]) = rho_norm;
                     arr(i, j, k, iUx_I[iSp]) =
-                        srcRhoUx[iSp] * normParams->Si2NoRho / get_Si2NoT();
+                        srcRhoUx[iSp] * get_Si2NoRho() / get_Si2NoT();
                     arr(i, j, k, iUy_I[iSp]) =
-                        srcRhoUy[iSp] * normParams->Si2NoRho / get_Si2NoT();
+                        srcRhoUy[iSp] * get_Si2NoRho() / get_Si2NoT();
                     arr(i, j, k, iUz_I[iSp]) =
-                        srcRhoUz[iSp] * normParams->Si2NoRho / get_Si2NoT();
+                        srcRhoUz[iSp] * get_Si2NoRho() / get_Si2NoT();
                     arr(i, j, k, iP_I[iSp]) =
-                        srcP[iSp] * normParams->Si2NoP / get_Si2NoT();
+                        srcP[iSp] * get_Si2NoP() / get_Si2NoT();
                   }
                 }
                 if (anySource && iPe >= 0) {
                   double srcPe = 0.0;
                   for (int iSp = 1; iSp <= nIonS; ++iSp)
                     srcPe += srcP[iSp];
-                  arr(i, j, k, iPe) = srcPe * normParams->Si2NoP / get_Si2NoT();
+                  arr(i, j, k, iPe) = srcPe * get_Si2NoP() / get_Si2NoT();
                 }
 
                 // ---- Compute ALL loss terms (after nodeFluid write) ----

--- a/userfiles/ExoSource.h
+++ b/userfiles/ExoSource.h
@@ -16,25 +16,25 @@ public:
 
   double get_exosphere_density(double r) const override {
     if (exosphereType == "None") return 0.0;
-    if (r < rPlanetSi) return 0.0;
+    if (r < normParams->rPlanetSi) return 0.0;
 
     double sum = 0.0;
     if (exosphereType == "Exponential") {
       for (int i = 0; i < nExoComponent; ++i) {
         if (exoH0[i] > 0.0) {
-          sum += exoN0[i] * exp(-(r - rPlanetSi) / exoH0[i]);
+          sum += exoN0[i] * exp(-(r - normParams->rPlanetSi) / exoH0[i]);
         }
       }
     } else if (exosphereType == "Power-Law") {
       for (int i = 0; i < nExoComponent; ++i) {
         if (r > 0.0) {
-          sum += exoN0[i] * pow(rPlanetSi / r, exoK0[i]);
+          sum += exoN0[i] * pow(normParams->rPlanetSi / r, exoK0[i]);
         }
       }
     } else if (exosphereType == "Chamberlain") {
       for (int i = 0; i < nExoComponent; ++i) {
-        if (rPlanetSi > 0.0 && r > 0.0) {
-          sum += exoN0[i] * exp(-exoH0[i] * (1.0 / rPlanetSi - 1.0 / r));
+        if (normParams->rPlanetSi > 0.0 && r > 0.0) {
+          sum += exoN0[i] * exp(-exoH0[i] * (1.0 / normParams->rPlanetSi - 1.0 / r));
         }
       }
     }
@@ -45,19 +45,19 @@ public:
                                          int iC) const override {
     if (exosphereType == "None") return 0.0;
     if (iC < 0 || iC >= nExoComponent) return 0.0;
-    if (r < rPlanetSi) return 0.0;
+    if (r < normParams->rPlanetSi) return 0.0;
 
     if (exosphereType == "Exponential") {
       if (exoH0[iC] > 0.0) {
-        return exoN0[iC] * exp(-(r - rPlanetSi) / exoH0[iC]);
+        return exoN0[iC] * exp(-(r - normParams->rPlanetSi) / exoH0[iC]);
       }
     } else if (exosphereType == "Power-Law") {
       if (r > 0.0) {
-        return exoN0[iC] * pow(rPlanetSi / r, exoK0[iC]);
+        return exoN0[iC] * pow(normParams->rPlanetSi / r, exoK0[iC]);
       }
     } else if (exosphereType == "Chamberlain") {
-      if (rPlanetSi > 0.0 && r > 0.0) {
-        return exoN0[iC] * exp(-exoH0[iC] * (1.0 / rPlanetSi - 1.0 / r));
+      if (normParams->rPlanetSi > 0.0 && r > 0.0) {
+        return exoN0[iC] * exp(-exoH0[iC] * (1.0 / normParams->rPlanetSi - 1.0 / r));
       }
     }
     return 0.0;
@@ -113,7 +113,7 @@ public:
     if (is_in_shadow(xyz[0], xyz[1], xyz[2])) return 0.0;
     double r2 = xyz[0] * xyz[0] + xyz[1] * xyz[1] + xyz[2] * xyz[2];
     double r_m = sqrt(r2);
-    double ratio = rPlanetSi / r_m;
+    double ratio = normParams->rPlanetSi / r_m;
     // Geometric dilution: nu = nu0 * (r_planet / r)^2
     return photoNu0[iC] * ratio * ratio;
   }
@@ -391,7 +391,7 @@ public:
     if (rxn.rateType == 1) {
       // Photoionization: rate = nu0 * (Rp/r)^2 [s^-1]
       if (is_in_shadow(xyz[0], xyz[1], xyz[2])) return 0.0;
-      double ratio = rPlanetSi / r_val;
+      double ratio = normParams->rPlanetSi / r_val;
       return rxn.rateCoef * ratio * ratio;
     }
 
@@ -410,8 +410,8 @@ public:
     }
 
     // Recombination: rate = k * n_e [s^-1]
-    // ne is normalized; convert to SI: n_si = n_norm / (Si2NoRho * mp)
-    return k_si * ne / (Si2NoRho * cProtonMassSI);
+    // ne is normalized; convert to SI: n_si = n_norm / (normParams->Si2NoRho * mp)
+    return k_si * ne / (normParams->Si2NoRho * cProtonMassSI);
   }
 
   //-------------------------------------------------------------------
@@ -444,9 +444,9 @@ public:
       double mass_reac = get_species_mass(iSpReac);
       // Normalized number density: n_norm = rho_norm / mass_amu
       double n_reac_norm = rho_reac_norm / mass_reac;
-      // Convert to SI: n_si = n_norm / (Si2NoRho * cProtonMassSI)
+      // Convert to SI: n_si = n_norm / (normParams->Si2NoRho * cProtonMassSI)
       double n_reac_si =
-          n_reac_norm / (Si2NoRho * cProtonMassSI);
+          n_reac_norm / (normParams->Si2NoRho * cProtonMassSI);
 
       // Source mass density rate (SI): srcRho = rate * n_si * m_prod * mp
       double srcRho_si =
@@ -466,7 +466,7 @@ public:
       // product: srcP = rate * P_reac (SI) [Pa/s].
       double p_reac_norm =
           other.get_value(mfi, idx, iP_I[iSpReac], iLev);
-      double p_reac_si = p_reac_norm / Si2NoP;
+      double p_reac_si = p_reac_norm / normParams->Si2NoP;
       srcP[iSpProd] += rate * p_reac_si;
     } else {
       // Photoionization: source from neutral at rest (zero velocity).
@@ -534,12 +534,12 @@ public:
 
       // Loss rate (normalized):
       // lossRho_si = k_si * ne_si * rho_ion_si
-      // lossRho_norm = lossRho_si * Si2NoRho / Si2NoT
-      //             = k_si * [ne/(Si2NoRho*mp)] * [rho_norm/Si2NoRho] *
-      //               Si2NoRho / Si2NoT
-      //             = k_si * ne * rho_norm / (Si2NoRho * mp * Si2NoT)
+      // lossRho_norm = lossRho_si * normParams->Si2NoRho / Si2NoT
+      //             = k_si * [ne/(normParams->Si2NoRho*mp)] * [rho_norm/normParams->Si2NoRho] *
+      //               normParams->Si2NoRho / Si2NoT
+      //             = k_si * ne * rho_norm / (normParams->Si2NoRho * mp * Si2NoT)
       double lossRho_norm = k_si * ne * rho_ion_norm /
-          (Si2NoRho * cProtonMassSI * get_Si2NoT());
+          (normParams->Si2NoRho * cProtonMassSI * get_Si2NoT());
       if (lossRho_norm > 0.0) {
         lossArr(i, j, k, iIon) = lossRho_norm;
       }
@@ -696,23 +696,23 @@ public:
                 for (int iSp = 1; iSp <= nIonS; ++iSp) {
                   if (srcRho[iSp] > 0) {
                     anySource = true;
-                    double rho_norm = srcRho[iSp] * Si2NoRho / get_Si2NoT();
+                    double rho_norm = srcRho[iSp] * normParams->Si2NoRho / get_Si2NoT();
                     arr(i, j, k, iRho_I[iSp]) = rho_norm;
                     arr(i, j, k, iUx_I[iSp]) =
-                        srcRhoUx[iSp] * Si2NoRho / get_Si2NoT();
+                        srcRhoUx[iSp] * normParams->Si2NoRho / get_Si2NoT();
                     arr(i, j, k, iUy_I[iSp]) =
-                        srcRhoUy[iSp] * Si2NoRho / get_Si2NoT();
+                        srcRhoUy[iSp] * normParams->Si2NoRho / get_Si2NoT();
                     arr(i, j, k, iUz_I[iSp]) =
-                        srcRhoUz[iSp] * Si2NoRho / get_Si2NoT();
+                        srcRhoUz[iSp] * normParams->Si2NoRho / get_Si2NoT();
                     arr(i, j, k, iP_I[iSp]) =
-                        srcP[iSp] * Si2NoP / get_Si2NoT();
+                        srcP[iSp] * normParams->Si2NoP / get_Si2NoT();
                   }
                 }
                 if (anySource && iPe >= 0) {
                   double srcPe = 0.0;
                   for (int iSp = 1; iSp <= nIonS; ++iSp)
                     srcPe += srcP[iSp];
-                  arr(i, j, k, iPe) = srcPe * Si2NoP / get_Si2NoT();
+                  arr(i, j, k, iPe) = srcPe * normParams->Si2NoP / get_Si2NoT();
                 }
 
                 // ---- Compute ALL loss terms (after nodeFluid write) ----

--- a/userfiles/ExoSource.h
+++ b/userfiles/ExoSource.h
@@ -6,8 +6,8 @@
 class UserSource : public SourceInterface {
 public:
   UserSource(const FluidInterface& other, int id, std::string tag,
-             FluidType typeIn = SourceFluid)
-      : SourceInterface(other, id, tag, typeIn) {
+             FluidType typeIn, const DomainParameters& dp)
+      : SourceInterface(other, id, tag, typeIn, dp) {
     info = "Exosphere Source";
     useFluidSource = true;
   }


### PR DESCRIPTION
Handles the parameter reading bug found in #54. Refactor part of the parameter loading for the source terms and particle tracer in the standalone FLEKS runs.

- Particle tracker parameter loading is now done via the `ParticleTrackerInfo` class in Particles.h.
- The `ParticleTracker` class now initializes based on the `ParticleTrackerInfo` instance.